### PR TITLE
Implement `KNIFE` EnchantmentCategory using Fabric-ASM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,9 @@ dependencies {
     include(implementation(annotationProcessor("io.github.llamalad7:mixinextras-fabric:${mixin_extras_version}")))
     annotationProcessor 'net.fabricmc:sponge-mixin:0.12.5+mixin.0.8.5'
 
+    include(modImplementation("com.github.Chocohead:Fabric-ASM:${fabric_asm_version}")) {
+        exclude (group: "net.fabricmc.fabric-api")
+    }
 
     for (String module in port_lib_modules.split(",")) {
         include(modApi("io.github.fabricators_of_create.Porting-Lib:$module:$port_lib_version"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,6 +38,7 @@ loader_version_range = [47,)
 
 # Other deps
 mixin_extras_version = 0.2.2
+fabric_asm_version = v2.3
 jei_version = 15.0.0.12
 rei_version = 12.0.684
 emi_version = 1.1.4+1.20.1

--- a/src/main/java/vectorwing/farmersdelight/FarmersDelightASM.java
+++ b/src/main/java/vectorwing/farmersdelight/FarmersDelightASM.java
@@ -1,0 +1,17 @@
+package vectorwing.farmersdelight;
+
+import com.chocohead.mm.api.ClassTinkerers;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.MappingResolver;
+
+public class FarmersDelightASM implements Runnable {
+    public static final String KNIFE_ENCHANTMENT_CATEGORY = "FARMERS_DELIGHT_KNIFE";
+
+    @Override
+    public void run() {
+        MappingResolver remapper = FabricLoader.getInstance().getMappingResolver();
+        String enchantmentTarget = remapper.mapClassName("intermediary", "net.minecraft.class_1886");
+        ClassTinkerers.enumBuilder(enchantmentTarget).addEnumSubclass(KNIFE_ENCHANTMENT_CATEGORY, "vectorwing.farmersdelight.common.item.enchantment.category.KnifeEnchantmentCategory").build();
+    }
+
+}

--- a/src/main/java/vectorwing/farmersdelight/common/item/enchantment/BackstabbingEnchantment.java
+++ b/src/main/java/vectorwing/farmersdelight/common/item/enchantment/BackstabbingEnchantment.java
@@ -13,20 +13,12 @@ import net.minecraft.world.item.enchantment.EnchantmentCategory;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
-import vectorwing.farmersdelight.common.item.KnifeItem;
 import vectorwing.farmersdelight.common.registry.ModEnchantments;
 
 public class BackstabbingEnchantment extends Enchantment
 {
 	public BackstabbingEnchantment(Rarity rarity, EnchantmentCategory category, EquipmentSlot... applicableSlots) {
 		super(rarity, category, applicableSlots);
-	}
-
-	// This does not implement the super method, which will break other mods
-	// that modify it. There's not much I can really do about this.
-	@Override
-	public boolean canEnchant(ItemStack stack) {
-		return stack.getItem() instanceof KnifeItem;
 	}
 
 	@Override

--- a/src/main/java/vectorwing/farmersdelight/common/item/enchantment/category/AbstractEnchantmentCategory.java
+++ b/src/main/java/vectorwing/farmersdelight/common/item/enchantment/category/AbstractEnchantmentCategory.java
@@ -1,0 +1,20 @@
+package vectorwing.farmersdelight.common.item.enchantment.category;
+
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.enchantment.EnchantmentCategory;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+/**
+ * <p>Pseudo class for Fabric-ASM, not needed in mixins.json.</p>
+ * <p>Extends this class and add the subclass as a {@link EnchantmentCategory} using {@link com.chocohead.mm.api.ClassTinkerers#enumBuilder(String)}.</p>
+ * @see vectorwing.farmersdelight.FarmersDelightASM
+ */
+@SuppressWarnings("all")
+@Mixin(EnchantmentCategory.class)
+public abstract class AbstractEnchantmentCategory {
+
+    @Shadow
+    public abstract boolean canEnchant(Item item);
+
+}

--- a/src/main/java/vectorwing/farmersdelight/common/item/enchantment/category/KnifeEnchantmentCategory.java
+++ b/src/main/java/vectorwing/farmersdelight/common/item/enchantment/category/KnifeEnchantmentCategory.java
@@ -1,0 +1,17 @@
+package vectorwing.farmersdelight.common.item.enchantment.category;
+
+import net.minecraft.world.item.Item;
+import vectorwing.farmersdelight.common.item.KnifeItem;
+
+/**
+ * @see vectorwing.farmersdelight.common.registry.ModEnchantments#KNIFE
+ */
+@SuppressWarnings("unused")
+public class KnifeEnchantmentCategory extends AbstractEnchantmentCategory {
+
+    @Override
+    public boolean canEnchant(Item item) {
+        return item instanceof KnifeItem;
+    }
+
+}

--- a/src/main/java/vectorwing/farmersdelight/common/registry/ModEnchantments.java
+++ b/src/main/java/vectorwing/farmersdelight/common/registry/ModEnchantments.java
@@ -1,22 +1,23 @@
 package vectorwing.farmersdelight.common.registry;
 
+import com.chocohead.mm.api.ClassTinkerers;
 import io.github.fabricators_of_create.porting_lib.util.LazyRegistrar;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentCategory;
 import vectorwing.farmersdelight.FarmersDelight;
+import vectorwing.farmersdelight.FarmersDelightASM;
 import vectorwing.farmersdelight.common.item.enchantment.BackstabbingEnchantment;
 
 import java.util.function.Supplier;
 
 public class ModEnchantments
 {
-    // cant do on fabric :P
-	// public static final EnchantmentCategory KNIFE = EnchantmentCategory.create("knife", item -> item instanceof KnifeItem);
+    public static final EnchantmentCategory KNIFE = ClassTinkerers.getEnum(EnchantmentCategory.class, FarmersDelightASM.KNIFE_ENCHANTMENT_CATEGORY);
 
 	public static final LazyRegistrar<Enchantment> ENCHANTMENTS = LazyRegistrar.create(BuiltInRegistries.ENCHANTMENT, FarmersDelight.MODID);
 
 	public static final Supplier<Enchantment> BACKSTABBING = ENCHANTMENTS.register("backstabbing",
-			() -> new BackstabbingEnchantment(Enchantment.Rarity.UNCOMMON, EnchantmentCategory.WEAPON, EquipmentSlot.MAINHAND));
+			() -> new BackstabbingEnchantment(Enchantment.Rarity.UNCOMMON, KNIFE, EquipmentSlot.MAINHAND));
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,6 +24,9 @@
     "client": [
       "vectorwing.farmersdelight.client.FarmersDelightClient"
     ],
+    "mm:early_risers": [
+      "vectorwing.farmersdelight.FarmersDelightASM"
+    ],
     "jei_mod_plugin": [
       "vectorwing.farmersdelight.integration.jei.JEIPlugin"
     ],

--- a/src/main/resources/farmersdelight.accesswidener
+++ b/src/main/resources/farmersdelight.accesswidener
@@ -19,3 +19,5 @@ mutable field net/minecraft/world/level/levelgen/structure/pools/StructureTempla
 
 accessible field net/minecraft/world/level/block/DispenserBlock DISPENSER_REGISTRY Ljava/util/Map;
 extendable method net/minecraft/core/dispenser/DefaultDispenseItemBehavior dispense (Lnet/minecraft/core/BlockSource;Lnet/minecraft/world/item/ItemStack;)Lnet/minecraft/world/item/ItemStack;
+
+extendable class net/minecraft/world/item/enchantment/EnchantmentCategory


### PR DESCRIPTION
As the title stated, this PR provides an implementation for FD's custom `KNIFE` EnchantmentCategory using Fabric-ASM.

### Changes
- Restored the `KNIFE` field in `ModEnchantments` so addons may use it for custom knife enchantments.
- Removed `BackstabbingEnchantment#canEnchant`, which shall prevent possible conflicts with mod that modifies the `Enchantment` class.
- Introduced Fabric-ASM dependency, currently bundled using jar in jar.