### PR TITLE
Register villager wanted items in `1.21`

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/FarmersDelight.java
+++ b/src/main/java/vectorwing/farmersdelight/FarmersDelight.java
@@ -58,7 +58,7 @@ public class FarmersDelight implements ModInitializer
 		CommonModBusEvents.init();
 		VillagerEvents.init();
 
-		CommonSetup.registerDispenserBehaviors();
+		CommonSetup.init();
 
 		// new stuff
 		VanillaCrateEnabledCondition.init();

--- a/src/main/java/vectorwing/farmersdelight/common/CommonSetup.java
+++ b/src/main/java/vectorwing/farmersdelight/common/CommonSetup.java
@@ -1,11 +1,35 @@
 package vectorwing.farmersdelight.common;
 
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import net.minecraft.world.entity.npc.Villager;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.DispenserBlock;
 import vectorwing.farmersdelight.common.registry.ModItems;
 
+import java.util.Set;
+
 public class CommonSetup
 {
+	public static void init() {
+		registerDispenserBehaviors();
+		registerItemSetAdditions();
+	}
+
 	public static void registerDispenserBehaviors() {
 		DispenserBlock.registerProjectileBehavior(ModItems.ROTTEN_TOMATO.get());
+	}
+
+	public static void registerItemSetAdditions() {
+		Set<Item> newWantedItems = Sets.newHashSet(
+				ModItems.CABBAGE.get(),
+				ModItems.TOMATO.get(),
+				ModItems.ONION.get(),
+				ModItems.RICE.get(),
+				ModItems.CABBAGE_SEEDS.get(),
+				ModItems.TOMATO_SEEDS.get(),
+				ModItems.RICE_PANICLE.get());
+		newWantedItems.addAll(Villager.WANTED_ITEMS);
+		Villager.WANTED_ITEMS = ImmutableSet.copyOf(newWantedItems);
 	}
 }

--- a/src/main/resources/farmersdelight.accesswidener
+++ b/src/main/resources/farmersdelight.accesswidener
@@ -2,6 +2,9 @@ accessWidener   v2  named
 
 accessible class net/minecraft/world/item/enchantment/EnchantmentHelper$EnchantmentVisitor
 
+accessible field net/minecraft/world/entity/npc/Villager WANTED_ITEMS Ljava/util/Set;
+mutable field net/minecraft/world/entity/npc/Villager WANTED_ITEMS Ljava/util/Set;
+
 accessible field net/minecraft/world/entity/Mob goalSelector Lnet/minecraft/world/entity/ai/goal/GoalSelector;
 
 accessible field net/minecraft/world/level/levelgen/structure/pools/StructureTemplatePool templates Lit/unimi/dsi/fastutil/objects/ObjectArrayList;


### PR DESCRIPTION
item additions for farmer villagers weren't being registered 

I added the accesswidener for villager wanted items, then registered wanted items like in the main mod

(would fix #159  for 1.21)