### PR TITLE
Fix Yellow Hanging Canvas Sign client item

### DIFF
--- a/src/main/resources/assets/farmersdelight/items/yellow_hanging_canvas_sign.json
+++ b/src/main/resources/assets/farmersdelight/items/yellow_hanging_canvas_sign.json
@@ -1,6 +1,6 @@
 {
   "model": {
     "type": "minecraft:model",
-    "model": "farmersdelight:item/blue_canvas_sign"
+    "model": "farmersdelight:item/yellow_hanging_canvas_sign"
   }
 }


### PR DESCRIPTION
Fixes the client item for the Yellow Hanging Canvas Sign, as reported in the Greenhouse Discord.