### PR TITLE
Fix signs not rendering text

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/client/renderer/ICanvasSignRenderer.java
+++ b/src/main/java/vectorwing/farmersdelight/client/renderer/ICanvasSignRenderer.java
@@ -135,7 +135,7 @@ public interface ICanvasSignRenderer {
             int red = (int) ((double) ARGB.red(textColor) * brightness);
             int green = (int) ((double) ARGB.green(textColor) * brightness);
             int blue = (int) ((double) ARGB.blue(textColor) * brightness);
-            return ARGB.color(0, red, green, blue);
+            return ARGB.color(255, red, green, blue);
         }
     }
 


### PR DESCRIPTION
1.21.6 caused text with no alpha value to become transparent, causing Farmer's Delight's canvas signs to not render their text. 

Fixes #199.