### PR TITLE
[1.20] Fix maven instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ I am open to constructive feedback about the mod's code: if you spot any glaring
 [Addons/Integration support for both ports.](./information/Addons_And_Integrations.md)
 
 ### Depending on Farmer's Delight Refabricated
-Starting from 2.0.7, Farmer's Delight Refabricated can be depended on within development environments through the Greenhouse Maven (https://repo.greenhouse.house/).
+Starting from 2.0.7, Farmer's Delight Refabricated can be depended on within development environments through the Greenhouse Maven (https://maven.greenhouse.lgbt/).
 
 To do so, assuming you have a field in your gradle.properties named `fdrf_version`.
 ```groovy
 repositories {
     maven {
         name = "Greenhouse Maven"
-        url = 'https://repo.greenhouse.house/releases/'
+        url = 'https://maven.greenhouse.lgbt/releases/'
     }
     maven { url "https://mvn.devos.one/releases/" } // Porting Lib
     maven {


### PR DESCRIPTION
Greenhouse maven's URL moved recently, and attempting to use the old link causes a `Doctype already seen error`.