### PR TITLE
Start restoring JEI support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.11-SNAPSHOT'
+    id 'fabric-loom' version '1.13-SNAPSHOT'
     id 'maven-publish'
     id "me.modmuss50.mod-publish-plugin" version "0.8.4"
 }
@@ -103,10 +103,10 @@ dependencies {
     // Uncomment the below to test CraftTweaker.
     // modLocalRuntime("com.blamejared.crafttweaker:CraftTweaker-fabric-${minecraft_version}:${crafttweaker_version}")
 
-//    modCompileOnly("mezz.jei:jei-${minecraft_version}-common-api:${jei_version}")
-//    modCompileOnly("mezz.jei:jei-${minecraft_version}-fabric-api:${jei_version}")
+    modCompileOnly("mezz.jei:jei-${minecraft_version}-common-api:${jei_version}")
+    modCompileOnly("mezz.jei:jei-${minecraft_version}-fabric-api:${jei_version}")
     // Uncomment the below to test JEI.
-    // modLocalRuntime("mezz.jei:jei-${minecraft_version}-fabric:${jei_version}")
+     modLocalRuntime("mezz.jei:jei-${minecraft_version}-fabric:${jei_version}")
 
     modCompileOnly("me.shedaniel.cloth:basic-math:0.6.1")
     modCompileOnly("dev.architectury:architectury-fabric:18.0.3")

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,11 +25,11 @@ modrinth_project_id = 7vxePowz
 parchment_version = 1.21.9:2025.10.05
 
 fabric_loader_version = 0.17.2
-fabric_api_version = 0.134.1+1.21.10
+fabric_api_version = 0.137.0+1.21.10
 
 # Other deps
 fabric_asm_version = v2.3
-jei_version = 25.0.1.4
+jei_version = 26.1.0.16
 rei_version = 20.0.811
 emi_version = 1.1.12+1.21
 eiv_version = 5.0.1+1.21.10

--- a/src/main/java/vectorwing/farmersdelight/FarmersDelight.java
+++ b/src/main/java/vectorwing/farmersdelight/FarmersDelight.java
@@ -2,7 +2,11 @@ package vectorwing.farmersdelight;
 
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.CommonLifecycleEvents;
+import net.fabricmc.fabric.api.event.registry.RegistryEntryAddedCallback;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.fabricmc.fabric.api.recipe.v1.sync.RecipeSynchronization;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.GameRules;
 import org.slf4j.Logger;
@@ -13,6 +17,7 @@ import vectorwing.farmersdelight.common.block.CuttingBoardBlock;
 import vectorwing.farmersdelight.common.block.RichSoilBlock;
 import vectorwing.farmersdelight.common.block.entity.CookingPotBlockEntity;
 import vectorwing.farmersdelight.common.block.entity.CuttingBoardBlockEntity;
+import vectorwing.farmersdelight.common.crafting.CookingPotRecipe;
 import vectorwing.farmersdelight.common.crafting.condition.VanillaCrateEnabledCondition;
 import vectorwing.farmersdelight.common.crafting.ingredient.ItemAbilityIngredient;
 import vectorwing.farmersdelight.common.event.CommonModBusEvents;
@@ -23,6 +28,7 @@ import vectorwing.farmersdelight.common.item.KnifeItem;
 import vectorwing.farmersdelight.common.networking.ModNetworking;
 import vectorwing.farmersdelight.common.registry.*;
 import vectorwing.farmersdelight.common.world.VillageStructures;
+import vectorwing.farmersdelight.integration.jei.FDRecipeTypes;
 import vectorwing.farmersdelight.refabricated.CanItemPerformAbilityCondition;
 import vectorwing.farmersdelight.refabricated.CompostableHelper;
 import vectorwing.farmersdelight.refabricated.LootModificationEvents;
@@ -85,5 +91,9 @@ public class FarmersDelight implements ModInitializer
 
 		ServerPlayerEvents.JOIN.register(serverPlayer ->
 				ServerPlayNetworking.send(serverPlayer, new ModNetworking.SendNaturalRegenerationValueMessage(serverPlayer.level().getGameRules().getBoolean(GameRules.RULE_NATURAL_REGENERATION))));
-	}
+//       FIXME - Stream codecs on these appear broke.
+//        RecipeSynchronization.synchronizeRecipeSerializer(ModRecipeSerializers.COOKING.get());
+//        RecipeSynchronization.synchronizeRecipeSerializer(ModRecipeSerializers.CUTTING.get());
+
+    }
 }

--- a/src/main/java/vectorwing/farmersdelight/FarmersDelight.java
+++ b/src/main/java/vectorwing/farmersdelight/FarmersDelight.java
@@ -2,11 +2,8 @@ package vectorwing.farmersdelight;
 
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
-import net.fabricmc.fabric.api.event.lifecycle.v1.CommonLifecycleEvents;
-import net.fabricmc.fabric.api.event.registry.RegistryEntryAddedCallback;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.fabricmc.fabric.api.recipe.v1.sync.RecipeSynchronization;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.GameRules;
 import org.slf4j.Logger;
@@ -17,7 +14,6 @@ import vectorwing.farmersdelight.common.block.CuttingBoardBlock;
 import vectorwing.farmersdelight.common.block.RichSoilBlock;
 import vectorwing.farmersdelight.common.block.entity.CookingPotBlockEntity;
 import vectorwing.farmersdelight.common.block.entity.CuttingBoardBlockEntity;
-import vectorwing.farmersdelight.common.crafting.CookingPotRecipe;
 import vectorwing.farmersdelight.common.crafting.condition.VanillaCrateEnabledCondition;
 import vectorwing.farmersdelight.common.crafting.ingredient.ItemAbilityIngredient;
 import vectorwing.farmersdelight.common.event.CommonModBusEvents;
@@ -28,7 +24,6 @@ import vectorwing.farmersdelight.common.item.KnifeItem;
 import vectorwing.farmersdelight.common.networking.ModNetworking;
 import vectorwing.farmersdelight.common.registry.*;
 import vectorwing.farmersdelight.common.world.VillageStructures;
-import vectorwing.farmersdelight.integration.jei.FDRecipeTypes;
 import vectorwing.farmersdelight.refabricated.CanItemPerformAbilityCondition;
 import vectorwing.farmersdelight.refabricated.CompostableHelper;
 import vectorwing.farmersdelight.refabricated.LootModificationEvents;
@@ -91,9 +86,8 @@ public class FarmersDelight implements ModInitializer
 
 		ServerPlayerEvents.JOIN.register(serverPlayer ->
 				ServerPlayNetworking.send(serverPlayer, new ModNetworking.SendNaturalRegenerationValueMessage(serverPlayer.level().getGameRules().getBoolean(GameRules.RULE_NATURAL_REGENERATION))));
-//       FIXME - Stream codecs on these appear broke.
-//        RecipeSynchronization.synchronizeRecipeSerializer(ModRecipeSerializers.COOKING.get());
-//        RecipeSynchronization.synchronizeRecipeSerializer(ModRecipeSerializers.CUTTING.get());
 
+        RecipeSynchronization.synchronizeRecipeSerializer(ModRecipeSerializers.COOKING.get());
+        RecipeSynchronization.synchronizeRecipeSerializer(ModRecipeSerializers.CUTTING.get());
     }
 }

--- a/src/main/java/vectorwing/farmersdelight/common/block/entity/CuttingBoardBlockEntity.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/entity/CuttingBoardBlockEntity.java
@@ -7,7 +7,6 @@ import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.registries.Registries;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvent;
@@ -45,7 +44,6 @@ public class CuttingBoardBlockEntity extends SyncedBlockEntity
 {
 	private final ItemStackHandler inventory;
 	private final RecipeManager.CachedCheck<CuttingBoardRecipeInput, CuttingBoardRecipe> quickCheck;
-	private ResourceLocation lastRecipeID;
 	private boolean isItemCarvingBoard;
 
 	public CuttingBoardBlockEntity(BlockPos pos, BlockState state) {
@@ -111,7 +109,7 @@ public class CuttingBoardBlockEntity extends SyncedBlockEntity
 				});
 			}
 
-			playProcessingSound(recipe.value().getSoundEvent().orElse(null), toolStack, getStoredItem());
+            playProcessingSound(recipe.value().getSoundEvent().orElse(null), toolStack, getStoredItem());
 			removeItem();
 			if (player instanceof ServerPlayer) {
 				ModAdvancements.USE_CUTTING_BOARD.get().trigger((ServerPlayer) player);

--- a/src/main/java/vectorwing/farmersdelight/common/crafting/CookingPotRecipe.java
+++ b/src/main/java/vectorwing/farmersdelight/common/crafting/CookingPotRecipe.java
@@ -190,7 +190,7 @@ public class CookingPotRecipe implements Recipe<RecipeWrapper>
 		private static CookingPotRecipe fromNetwork(RegistryFriendlyByteBuf buffer) {
 			String groupIn = buffer.readUtf();
 			CookingPotBookCategory tabIn = CookingPotBookCategory.STREAM_CODEC.decode(buffer);
-			List<Ingredient> inputItemsIn = Ingredient.CONTENTS_STREAM_CODEC.apply(ByteBufCodecs.list(6)).decode(buffer);
+			List<Ingredient> inputItemsIn = Ingredient.CONTENTS_STREAM_CODEC.apply(ByteBufCodecs.list()).decode(buffer);
 			ItemStack outputIn = ItemStack.STREAM_CODEC.decode(buffer);
 			ItemStack container = ItemStack.OPTIONAL_STREAM_CODEC.decode(buffer);
 			float experienceIn = buffer.readFloat();
@@ -201,7 +201,7 @@ public class CookingPotRecipe implements Recipe<RecipeWrapper>
 		private static void toNetwork(RegistryFriendlyByteBuf buffer, CookingPotRecipe recipe) {
 			buffer.writeUtf(recipe.group);
 			buffer.writeUtf(recipe.category != null ? recipe.category.toString() : "");
-			Ingredient.CONTENTS_STREAM_CODEC.apply(ByteBufCodecs.list(6)).encode(buffer, recipe.inputItems);
+			Ingredient.CONTENTS_STREAM_CODEC.apply(ByteBufCodecs.list()).encode(buffer, recipe.inputItems);
 			ItemStack.STREAM_CODEC.encode(buffer, recipe.result);
 			ItemStack.OPTIONAL_STREAM_CODEC.encode(buffer, recipe.container);
 			buffer.writeFloat(recipe.experience);

--- a/src/main/java/vectorwing/farmersdelight/common/crafting/CookingPotRecipe.java
+++ b/src/main/java/vectorwing/farmersdelight/common/crafting/CookingPotRecipe.java
@@ -200,7 +200,7 @@ public class CookingPotRecipe implements Recipe<RecipeWrapper>
 
 		private static void toNetwork(RegistryFriendlyByteBuf buffer, CookingPotRecipe recipe) {
 			buffer.writeUtf(recipe.group);
-			buffer.writeUtf(recipe.category != null ? recipe.category.toString() : "");
+            CookingPotBookCategory.STREAM_CODEC.encode(buffer, recipe.category);
 			Ingredient.CONTENTS_STREAM_CODEC.apply(ByteBufCodecs.list()).encode(buffer, recipe.inputItems);
 			ItemStack.STREAM_CODEC.encode(buffer, recipe.result);
 			ItemStack.OPTIONAL_STREAM_CODEC.encode(buffer, recipe.container);

--- a/src/main/java/vectorwing/farmersdelight/common/crafting/CuttingBoardRecipe.java
+++ b/src/main/java/vectorwing/farmersdelight/common/crafting/CuttingBoardRecipe.java
@@ -3,8 +3,8 @@ package vectorwing.farmersdelight.common.crafting;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
@@ -13,6 +13,7 @@ import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.*;
 import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.Nullable;
 import vectorwing.farmersdelight.common.crafting.ingredient.ChanceResult;
 import vectorwing.farmersdelight.common.registry.ModRecipeBookCategories;
 import vectorwing.farmersdelight.common.registry.ModRecipeSerializers;
@@ -32,15 +33,21 @@ public class CuttingBoardRecipe implements Recipe<CuttingBoardRecipeInput>
 	private final Ingredient input;
 	private final Ingredient tool;
 	private final List<ChanceResult> results;
-	private final Optional<SoundEvent> soundEvent;
+    @Nullable
+	private final Holder<SoundEvent> soundEvent;
 
-	public CuttingBoardRecipe(String group, Ingredient input, Ingredient tool, List<ChanceResult> results, Optional<SoundEvent> soundEvent) {
+	public CuttingBoardRecipe(String group, Ingredient input, Ingredient tool, List<ChanceResult> results, @Nullable Holder<SoundEvent> soundEvent) {
 		this.group = group;
 		this.input = input;
 		this.tool = tool;
 		this.results = results;
 		this.soundEvent = soundEvent;
 	}
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    private CuttingBoardRecipe(String group, Ingredient input, Ingredient tool, List<ChanceResult> results, Optional<Holder<SoundEvent>> soundEvent) {
+        this(group, input, tool, results, soundEvent.orElse(null));
+    }
 
 	@Override
 	public boolean matches(CuttingBoardRecipeInput input, Level level) {
@@ -92,8 +99,12 @@ public class CuttingBoardRecipe implements Recipe<CuttingBoardRecipeInput>
 	}
 
 	public Optional<SoundEvent> getSoundEvent() {
-		return this.soundEvent;
+		return getSoundEventHolder().map(Holder::value);
 	}
+
+    public Optional<Holder<SoundEvent>> getSoundEventHolder() {
+        return Optional.ofNullable(this.soundEvent);
+    }
 
 	@Override
 	public RecipeSerializer<CuttingBoardRecipe> getSerializer() {
@@ -131,12 +142,7 @@ public class CuttingBoardRecipe implements Recipe<CuttingBoardRecipeInput>
 
 	@Override
 	public int hashCode() {
-		int result = (group() != null ? group().hashCode() : 0);
-		result = 31 * result + input.hashCode();
-		result = 31 * result + getTool().hashCode();
-		result = 31 * result + getResults().hashCode();
-		result = 31 * result + (soundEvent.map(Object::hashCode).orElse(0));
-		return result;
+        return Objects.hash(group, input, tool, results, soundEvent);
 	}
 
 	public static class Serializer implements RecipeSerializer<CuttingBoardRecipe>
@@ -147,10 +153,10 @@ public class CuttingBoardRecipe implements Recipe<CuttingBoardRecipeInput>
 		private static final MapCodec<CuttingBoardRecipe> CODEC = RecordCodecBuilder.mapCodec(
 				inst -> inst.group(Codec.STRING.optionalFieldOf("group", "").forGetter(CuttingBoardRecipe::group),
 								// List::getFirst does not compile...
-								Ingredient.CODEC.listOf(1, 1).fieldOf("ingredients").xmap(ingredients -> ingredients.get(0), List::of).forGetter(cuttingBoardRecipe -> cuttingBoardRecipe.input),
+								Ingredient.CODEC.listOf(1, 1).fieldOf("ingredients").xmap(List::getFirst, List::of).forGetter(cuttingBoardRecipe -> cuttingBoardRecipe.input),
 								Ingredient.CODEC.fieldOf("tool").forGetter(CuttingBoardRecipe::getTool),
 								ChanceResult.CODEC.listOf(1, MAX_RESULTS).fieldOf("result").forGetter(CuttingBoardRecipe::getRollableResults),
-								SoundEvent.DIRECT_CODEC.optionalFieldOf("sound").forGetter(CuttingBoardRecipe::getSoundEvent))
+								SoundEvent.CODEC.optionalFieldOf("sound").forGetter(CuttingBoardRecipe::getSoundEventHolder))
 						.apply(inst, CuttingBoardRecipe::new));
 
 		public Serializer() {
@@ -161,9 +167,9 @@ public class CuttingBoardRecipe implements Recipe<CuttingBoardRecipeInput>
 			Ingredient inputItemIn = Ingredient.CONTENTS_STREAM_CODEC.decode(buffer);
 			Ingredient toolIn = Ingredient.CONTENTS_STREAM_CODEC.decode(buffer);
 			List<ChanceResult> resultsIn = ChanceResult.STREAM_CODEC.apply(ByteBufCodecs.list()).decode(buffer);
-			Optional<SoundEvent> soundEventIn = ByteBufCodecs.optional(ByteBufCodecs.registry(Registries.SOUND_EVENT)).decode(buffer);
+			Optional<Holder<SoundEvent>> soundEventIn = SoundEvent.STREAM_CODEC.apply(ByteBufCodecs::optional).decode(buffer);
 
-			return new CuttingBoardRecipe(groupIn, inputItemIn, toolIn, resultsIn, soundEventIn);
+			return new CuttingBoardRecipe(groupIn, inputItemIn, toolIn, resultsIn, soundEventIn.orElse(null));
 		}
 
 		public static void toNetwork(RegistryFriendlyByteBuf buffer, CuttingBoardRecipe recipe) {
@@ -171,7 +177,7 @@ public class CuttingBoardRecipe implements Recipe<CuttingBoardRecipeInput>
 			Ingredient.CONTENTS_STREAM_CODEC.encode(buffer, recipe.input);
 			Ingredient.CONTENTS_STREAM_CODEC.encode(buffer, recipe.tool);
 			ChanceResult.STREAM_CODEC.apply(ByteBufCodecs.list()).encode(buffer, recipe.results);
-			ByteBufCodecs.optional(ByteBufCodecs.registry(Registries.SOUND_EVENT)).encode(buffer, recipe.soundEvent);
+            SoundEvent.STREAM_CODEC.apply(ByteBufCodecs::optional).encode(buffer, Optional.ofNullable(recipe.soundEvent));
 		}
 
 		@Override

--- a/src/main/java/vectorwing/farmersdelight/data/builder/CuttingBoardRecipeBuilder.java
+++ b/src/main/java/vectorwing/farmersdelight/data/builder/CuttingBoardRecipeBuilder.java
@@ -21,15 +21,13 @@ import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.common.crafting.CuttingBoardRecipe;
 import vectorwing.farmersdelight.common.crafting.ingredient.ChanceResult;
 
-import java.util.Optional;
-
 @MethodsReturnNonnullByDefault
 public class CuttingBoardRecipeBuilder implements RecipeBuilder
 {
 	private final NonNullList<ChanceResult> results = NonNullList.createWithCapacity(4);
 	private final Ingredient ingredient;
 	private final Ingredient tool;
-	private SoundEvent soundEvent;
+	private Holder<SoundEvent> soundEvent;
 
 	private CuttingBoardRecipeBuilder(Ingredient ingredient, Ingredient tool, ItemLike mainResult, int count, float chance) {
 		this.results.add(new ChanceResult(new ItemStack(mainResult.asItem(), count), chance));
@@ -76,7 +74,12 @@ public class CuttingBoardRecipeBuilder implements RecipeBuilder
 		return this;
 	}
 
-	public CuttingBoardRecipeBuilder addSound(SoundEvent soundEvent) {
+    public CuttingBoardRecipeBuilder addSound(SoundEvent soundEvent) {
+        this.soundEvent = BuiltInRegistries.SOUND_EVENT.wrapAsHolder(soundEvent);
+        return this;
+    }
+
+	public CuttingBoardRecipeBuilder addSound(Holder<SoundEvent> soundEvent) {
 		this.soundEvent = soundEvent;
 		return this;
 	}
@@ -123,7 +126,7 @@ public class CuttingBoardRecipeBuilder implements RecipeBuilder
 				this.ingredient,
 				this.tool,
 				this.results,
-				this.soundEvent == null ? Optional.empty() : Optional.of(this.soundEvent)
+				this.soundEvent
 		);
 		output.accept(resourceKey, recipe, null);
 	}

--- a/src/main/java/vectorwing/farmersdelight/integration/jei/FDRecipeTypes.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/jei/FDRecipeTypes.java
@@ -1,17 +1,16 @@
-// TODO: Reupdate when JEI updates.
-//package vectorwing.farmersdelight.integration.jei;
-//
-//import mezz.jei.api.recipe.RecipeType;
-//import net.minecraft.world.item.crafting.RecipeHolder;
-//import vectorwing.farmersdelight.FarmersDelight;
-//import vectorwing.farmersdelight.common.crafting.CookingPotRecipe;
-//import vectorwing.farmersdelight.common.crafting.CuttingBoardRecipe;
-//import vectorwing.farmersdelight.common.registry.ModRecipeTypes;
-//import vectorwing.farmersdelight.integration.jei.resource.DecompositionDummy;
-//
-//public final class FDRecipeTypes
-//{
-//	public static final RecipeType<RecipeHolder<CookingPotRecipe>> COOKING = RecipeType.createFromVanilla(ModRecipeTypes.COOKING.get());
-//	public static final RecipeType<RecipeHolder<CuttingBoardRecipe>> CUTTING = RecipeType.createFromVanilla(ModRecipeTypes.CUTTING.get());
-//	public static final RecipeType<DecompositionDummy> DECOMPOSITION = RecipeType.create(FarmersDelight.MODID, "decomposition", DecompositionDummy.class);
-//}
+package vectorwing.farmersdelight.integration.jei;
+
+import mezz.jei.api.recipe.types.IRecipeType;
+import net.minecraft.world.item.crafting.RecipeHolder;
+import vectorwing.farmersdelight.FarmersDelight;
+import vectorwing.farmersdelight.common.crafting.CookingPotRecipe;
+import vectorwing.farmersdelight.common.crafting.CuttingBoardRecipe;
+import vectorwing.farmersdelight.common.registry.ModRecipeTypes;
+import vectorwing.farmersdelight.integration.jei.resource.DecompositionDummy;
+
+public final class FDRecipeTypes
+{
+	public static final IRecipeType<RecipeHolder<CookingPotRecipe>> COOKING = IRecipeType.create(ModRecipeTypes.COOKING.get());
+	public static final IRecipeType<RecipeHolder<CuttingBoardRecipe>> CUTTING = IRecipeType.create(ModRecipeTypes.CUTTING.get());
+	public static final IRecipeType<DecompositionDummy> DECOMPOSITION = IRecipeType.create(FarmersDelight.MODID, "decomposition", DecompositionDummy.class);
+}

--- a/src/main/java/vectorwing/farmersdelight/integration/jei/FDRecipes.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/jei/FDRecipes.java
@@ -3,7 +3,6 @@ package vectorwing.farmersdelight.integration.jei;
 import net.fabricmc.fabric.api.recipe.v1.sync.SynchronizedRecipes;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.crafting.RecipeHolder;
 import vectorwing.farmersdelight.common.crafting.CookingPotRecipe;
 import vectorwing.farmersdelight.common.crafting.CuttingBoardRecipe;
@@ -25,15 +24,9 @@ public class FDRecipes
 		} else {
 			throw new NullPointerException("minecraft world must not be null.");
 		}
-
 	}
 
 	public List<RecipeHolder<CookingPotRecipe>> getCookingPotRecipes() {
-        System.out.println("GET COOKING POT RECIPES");
-        for (RecipeHolder<CookingPotRecipe> cookingPotRecipeRecipeHolder : synchronizedRecipes.getAllOfType(ModRecipeTypes.COOKING.get())) {
-            System.out.println(cookingPotRecipeRecipeHolder.id());
-        }
-
         return List.copyOf(synchronizedRecipes.getAllOfType(ModRecipeTypes.COOKING.get()));
 	}
 

--- a/src/main/java/vectorwing/farmersdelight/integration/jei/FDRecipes.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/jei/FDRecipes.java
@@ -1,37 +1,43 @@
-// TODO: Reupdate when JEI updates.
-//package vectorwing.farmersdelight.integration.jei;
-//
-//import net.minecraft.client.Minecraft;
-//import net.minecraft.client.multiplayer.ClientLevel;
-//import net.minecraft.world.item.crafting.RecipeHolder;
-//import net.minecraft.world.item.crafting.RecipeManager;
-//import vectorwing.farmersdelight.common.crafting.CookingPotRecipe;
-//import vectorwing.farmersdelight.common.crafting.CuttingBoardRecipe;
-//import vectorwing.farmersdelight.common.registry.ModRecipeTypes;
-//
-//import java.util.List;
-//
-//public class FDRecipes
-//{
-//	private final RecipeManager recipeManager;
-//
-//	public FDRecipes() {
-//		Minecraft minecraft = Minecraft.getInstance();
-//		ClientLevel level = minecraft.level;
-//
-//		if (level != null) {
-//			this.recipeManager = level.getRecipeManager();
-//		} else {
-//			throw new NullPointerException("minecraft world must not be null.");
-//		}
-//	}
-//
-//	public List<RecipeHolder<CookingPotRecipe>> getCookingPotRecipes() {
-//		return recipeManager.getAllRecipesFor(ModRecipeTypes.COOKING.get());
-//	}
-//
-//	public List<RecipeHolder<CuttingBoardRecipe>> getCuttingBoardRecipes() {
-//		return recipeManager.getAllRecipesFor(ModRecipeTypes.CUTTING.get());
-//	}
-//}
-//
+package vectorwing.farmersdelight.integration.jei;
+
+import net.fabricmc.fabric.api.recipe.v1.sync.SynchronizedRecipes;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.item.crafting.RecipeHolder;
+import vectorwing.farmersdelight.common.crafting.CookingPotRecipe;
+import vectorwing.farmersdelight.common.crafting.CuttingBoardRecipe;
+import vectorwing.farmersdelight.common.registry.ModRecipeTypes;
+
+import java.util.List;
+
+public class FDRecipes
+{
+
+    private final SynchronizedRecipes synchronizedRecipes;
+
+    public FDRecipes() {
+        Minecraft minecraft = Minecraft.getInstance();
+		ClientLevel level = minecraft.level;
+
+		if (level != null) {
+            synchronizedRecipes = level.recipeAccess().getSynchronizedRecipes();
+		} else {
+			throw new NullPointerException("minecraft world must not be null.");
+		}
+
+	}
+
+	public List<RecipeHolder<CookingPotRecipe>> getCookingPotRecipes() {
+        System.out.println("GET COOKING POT RECIPES");
+        for (RecipeHolder<CookingPotRecipe> cookingPotRecipeRecipeHolder : synchronizedRecipes.getAllOfType(ModRecipeTypes.COOKING.get())) {
+            System.out.println(cookingPotRecipeRecipeHolder.id());
+        }
+
+        return List.copyOf(synchronizedRecipes.getAllOfType(ModRecipeTypes.COOKING.get()));
+	}
+
+	public List<RecipeHolder<CuttingBoardRecipe>> getCuttingBoardRecipes() {
+		return List.copyOf(synchronizedRecipes.getAllOfType(ModRecipeTypes.CUTTING.get()));
+	}
+}

--- a/src/main/java/vectorwing/farmersdelight/integration/jei/JEIPlugin.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/jei/JEIPlugin.java
@@ -6,7 +6,6 @@ import mezz.jei.api.JeiPlugin;
 import mezz.jei.api.constants.RecipeTypes;
 import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.registration.*;
-import net.fabricmc.fabric.api.client.recipe.v1.sync.ClientRecipeSynchronizedEvent;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
@@ -28,7 +27,6 @@ import java.util.List;
 
 @JeiPlugin
 @MethodsReturnNonnullByDefault
-@SuppressWarnings("unused")
 public class JEIPlugin implements IModPlugin
 {
 	private static final ResourceLocation ID = ResourceLocation.fromNamespaceAndPath(FarmersDelight.MODID, "jei_plugin");
@@ -47,7 +45,6 @@ public class JEIPlugin implements IModPlugin
         registration.addRecipes(FDRecipeTypes.COOKING, modRecipes.getCookingPotRecipes());
         registration.addRecipes(FDRecipeTypes.CUTTING, modRecipes.getCuttingBoardRecipes());
         registration.addRecipes(FDRecipeTypes.DECOMPOSITION, ImmutableList.of(new DecompositionDummy()));
-
 
 		registration.addRecipes(RecipeTypes.CRAFTING, DoughRecipeMaker.createRecipe());
 

--- a/src/main/java/vectorwing/farmersdelight/integration/jei/JEIPlugin.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/jei/JEIPlugin.java
@@ -1,95 +1,96 @@
-// TODO: Reupdate when JEI updates.
-//package vectorwing.farmersdelight.integration.jei;
-//
-//import com.google.common.collect.ImmutableList;
-//import mezz.jei.api.IModPlugin;
-//import mezz.jei.api.JeiPlugin;
-//import mezz.jei.api.constants.RecipeTypes;
-//import mezz.jei.api.constants.VanillaTypes;
-//import mezz.jei.api.registration.*;
-//import net.minecraft.MethodsReturnNonnullByDefault;
-//import net.minecraft.resources.ResourceLocation;
-//import net.minecraft.world.item.ItemStack;
-//import net.minecraft.world.item.Items;
-//import vectorwing.farmersdelight.FarmersDelight;
-//import vectorwing.farmersdelight.client.gui.CookingPotScreen;
-//import vectorwing.farmersdelight.common.block.entity.container.CookingPotMenu;
-//import vectorwing.farmersdelight.common.registry.ModBlocks;
-//import vectorwing.farmersdelight.common.registry.ModItems;
-//import vectorwing.farmersdelight.common.registry.ModMenuTypes;
-//import vectorwing.farmersdelight.common.utility.TextUtils;
-//import vectorwing.farmersdelight.integration.jei.category.CookingRecipeCategory;
-//import vectorwing.farmersdelight.integration.jei.category.CuttingRecipeCategory;
-//import vectorwing.farmersdelight.integration.jei.category.DecompositionRecipeCategory;
-//import vectorwing.farmersdelight.integration.jei.resource.DecompositionDummy;
-//import vectorwing.farmersdelight.integration.jei.resource.DoughRecipeMaker;
-//
-//import java.util.List;
-//
-//@JeiPlugin
-//@MethodsReturnNonnullByDefault
-//@SuppressWarnings("unused")
-//public class JEIPlugin implements IModPlugin
-//{
-//	private static final ResourceLocation ID = ResourceLocation.fromNamespaceAndPath(FarmersDelight.MODID, "jei_plugin");
-//
-//	@Override
-//	public void registerCategories(IRecipeCategoryRegistration registry) {
-//		registry.addRecipeCategories(new CookingRecipeCategory(registry.getJeiHelpers().getGuiHelper()));
-//		registry.addRecipeCategories(new CuttingRecipeCategory(registry.getJeiHelpers().getGuiHelper()));
-//		registry.addRecipeCategories(new DecompositionRecipeCategory(registry.getJeiHelpers().getGuiHelper()));
-//	}
-//
-//	@Override
-//	public void registerRecipes(IRecipeRegistration registration) {
-//		FDRecipes modRecipes = new FDRecipes();
-//		registration.addRecipes(FDRecipeTypes.COOKING, modRecipes.getCookingPotRecipes());
-//		registration.addRecipes(FDRecipeTypes.CUTTING, modRecipes.getCuttingBoardRecipes());
-//		registration.addRecipes(FDRecipeTypes.DECOMPOSITION, ImmutableList.of(new DecompositionDummy()));
-//
-//		registration.addRecipes(RecipeTypes.CRAFTING, DoughRecipeMaker.createRecipe());
-//
-//		registration.addIngredientInfo(new ItemStack(ModItems.WHEAT_DOUGH.get()), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.dough"));
-//		registration.addIngredientInfo(new ItemStack(ModItems.STRAW.get()), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.straw"));
-//		registration.addIngredientInfo(new ItemStack(ModItems.HAM.get()), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.ham"));
-//		registration.addIngredientInfo(new ItemStack(ModItems.SMOKED_HAM.get()), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.ham"));
-//		registration.addIngredientInfo(new ItemStack(ModItems.FLINT_KNIFE.get()), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.knife"));
-//		registration.addIngredientInfo(new ItemStack(ModItems.IRON_KNIFE.get()), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.knife"));
-//		registration.addIngredientInfo(new ItemStack(ModItems.DIAMOND_KNIFE.get()), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.knife"));
-//		registration.addIngredientInfo(new ItemStack(ModItems.NETHERITE_KNIFE.get()), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.knife"));
-//		registration.addIngredientInfo(new ItemStack(ModItems.GOLDEN_KNIFE.get()), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.knife"));
-//
-//		registration.addIngredientInfo(List.of(new ItemStack(ModItems.WILD_CABBAGES.get()), new ItemStack(ModItems.CABBAGE.get()), new ItemStack(ModItems.CABBAGE_LEAF.get())), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.wild_cabbages"));
-//		registration.addIngredientInfo(List.of(new ItemStack(ModItems.WILD_BEETROOTS.get()), new ItemStack(Items.BEETROOT)), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.wild_beetroots"));
-//		registration.addIngredientInfo(List.of(new ItemStack(ModItems.WILD_CARROTS.get()), new ItemStack(Items.CARROT)), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.wild_carrots"));
-//		registration.addIngredientInfo(List.of(new ItemStack(ModItems.WILD_ONIONS.get()), new ItemStack(ModItems.ONION.get())), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.wild_onions"));
-//		registration.addIngredientInfo(List.of(new ItemStack(ModItems.WILD_POTATOES.get()), new ItemStack(Items.POTATO)), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.wild_potatoes"));
-//		registration.addIngredientInfo(List.of(new ItemStack(ModItems.WILD_TOMATOES.get()), new ItemStack(ModItems.TOMATO.get())), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.wild_tomatoes"));
-//		registration.addIngredientInfo(List.of(new ItemStack(ModItems.WILD_RICE.get()), new ItemStack(ModItems.RICE.get()), new ItemStack(ModItems.RICE_PANICLE.get())), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.wild_rice"));
-//	}
-//
-//	@Override
-//	public void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
-//		registration.addRecipeCatalyst(new ItemStack(ModItems.COOKING_POT.get()), FDRecipeTypes.COOKING);
-//		registration.addRecipeCatalyst(new ItemStack(ModItems.CUTTING_BOARD.get()), FDRecipeTypes.CUTTING);
-//		registration.addRecipeCatalyst(new ItemStack(ModItems.STOVE.get()), RecipeTypes.CAMPFIRE_COOKING);
-//		registration.addRecipeCatalyst(new ItemStack(ModItems.SKILLET.get()), RecipeTypes.CAMPFIRE_COOKING);
-//		registration.addRecipeCatalyst(new ItemStack(ModBlocks.ORGANIC_COMPOST.get()), FDRecipeTypes.DECOMPOSITION);
-//	}
-//
-//	@Override
-//	public void registerGuiHandlers(IGuiHandlerRegistration registration) {
-//		registration.addRecipeClickArea(CookingPotScreen.class, 89, 25, 24, 17, FDRecipeTypes.COOKING);
-//	}
-//
-//	@Override
-//	public void registerRecipeTransferHandlers(IRecipeTransferRegistration registration) {
-//		registration.addRecipeTransferHandler(CookingPotMenu.class, ModMenuTypes.COOKING_POT.get(), FDRecipeTypes.COOKING, 0, 6, 9, 36);
-//	}
-//
-//	@Override
-//	public ResourceLocation getPluginUid() {
-//		return ID;
-//	}
-//}
-//
+package vectorwing.farmersdelight.integration.jei;
+
+import com.google.common.collect.ImmutableList;
+import mezz.jei.api.IModPlugin;
+import mezz.jei.api.JeiPlugin;
+import mezz.jei.api.constants.RecipeTypes;
+import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.registration.*;
+import net.fabricmc.fabric.api.client.recipe.v1.sync.ClientRecipeSynchronizedEvent;
+import net.minecraft.MethodsReturnNonnullByDefault;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import vectorwing.farmersdelight.FarmersDelight;
+import vectorwing.farmersdelight.client.gui.CookingPotScreen;
+import vectorwing.farmersdelight.common.block.entity.container.CookingPotMenu;
+import vectorwing.farmersdelight.common.registry.ModBlocks;
+import vectorwing.farmersdelight.common.registry.ModItems;
+import vectorwing.farmersdelight.common.registry.ModMenuTypes;
+import vectorwing.farmersdelight.common.utility.TextUtils;
+import vectorwing.farmersdelight.integration.jei.category.CookingRecipeCategory;
+import vectorwing.farmersdelight.integration.jei.category.CuttingRecipeCategory;
+import vectorwing.farmersdelight.integration.jei.category.DecompositionRecipeCategory;
+import vectorwing.farmersdelight.integration.jei.resource.DecompositionDummy;
+import vectorwing.farmersdelight.integration.jei.resource.DoughRecipeMaker;
+
+import java.util.List;
+
+@JeiPlugin
+@MethodsReturnNonnullByDefault
+@SuppressWarnings("unused")
+public class JEIPlugin implements IModPlugin
+{
+	private static final ResourceLocation ID = ResourceLocation.fromNamespaceAndPath(FarmersDelight.MODID, "jei_plugin");
+
+	@Override
+	public void registerCategories(IRecipeCategoryRegistration registry) {
+		registry.addRecipeCategories(new CookingRecipeCategory(registry.getJeiHelpers().getGuiHelper()));
+		registry.addRecipeCategories(new CuttingRecipeCategory(registry.getJeiHelpers().getGuiHelper()));
+		registry.addRecipeCategories(new DecompositionRecipeCategory(registry.getJeiHelpers().getGuiHelper()));
+	}
+
+	@Override
+	public void registerRecipes(IRecipeRegistration registration) {
+
+        FDRecipes modRecipes = new FDRecipes();
+        registration.addRecipes(FDRecipeTypes.COOKING, modRecipes.getCookingPotRecipes());
+        registration.addRecipes(FDRecipeTypes.CUTTING, modRecipes.getCuttingBoardRecipes());
+        registration.addRecipes(FDRecipeTypes.DECOMPOSITION, ImmutableList.of(new DecompositionDummy()));
+
+
+		registration.addRecipes(RecipeTypes.CRAFTING, DoughRecipeMaker.createRecipe());
+
+		registration.addIngredientInfo(new ItemStack(ModItems.WHEAT_DOUGH.get()), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.dough"));
+		registration.addIngredientInfo(new ItemStack(ModItems.STRAW.get()), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.straw"));
+		registration.addIngredientInfo(new ItemStack(ModItems.HAM.get()), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.ham"));
+		registration.addIngredientInfo(new ItemStack(ModItems.SMOKED_HAM.get()), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.ham"));
+		registration.addIngredientInfo(new ItemStack(ModItems.FLINT_KNIFE.get()), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.knife"));
+		registration.addIngredientInfo(new ItemStack(ModItems.IRON_KNIFE.get()), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.knife"));
+		registration.addIngredientInfo(new ItemStack(ModItems.DIAMOND_KNIFE.get()), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.knife"));
+		registration.addIngredientInfo(new ItemStack(ModItems.NETHERITE_KNIFE.get()), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.knife"));
+		registration.addIngredientInfo(new ItemStack(ModItems.GOLDEN_KNIFE.get()), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.knife"));
+
+		registration.addIngredientInfo(List.of(new ItemStack(ModItems.WILD_CABBAGES.get()), new ItemStack(ModItems.CABBAGE.get()), new ItemStack(ModItems.CABBAGE_LEAF.get())), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.wild_cabbages"));
+		registration.addIngredientInfo(List.of(new ItemStack(ModItems.WILD_BEETROOTS.get()), new ItemStack(Items.BEETROOT)), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.wild_beetroots"));
+		registration.addIngredientInfo(List.of(new ItemStack(ModItems.WILD_CARROTS.get()), new ItemStack(Items.CARROT)), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.wild_carrots"));
+		registration.addIngredientInfo(List.of(new ItemStack(ModItems.WILD_ONIONS.get()), new ItemStack(ModItems.ONION.get())), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.wild_onions"));
+		registration.addIngredientInfo(List.of(new ItemStack(ModItems.WILD_POTATOES.get()), new ItemStack(Items.POTATO)), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.wild_potatoes"));
+		registration.addIngredientInfo(List.of(new ItemStack(ModItems.WILD_TOMATOES.get()), new ItemStack(ModItems.TOMATO.get())), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.wild_tomatoes"));
+		registration.addIngredientInfo(List.of(new ItemStack(ModItems.WILD_RICE.get()), new ItemStack(ModItems.RICE.get()), new ItemStack(ModItems.RICE_PANICLE.get())), VanillaTypes.ITEM_STACK, TextUtils.getTranslation("jei.info.wild_rice"));
+	}
+
+	@Override
+	public void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
+		registration.addCraftingStation(FDRecipeTypes.COOKING, new ItemStack(ModItems.COOKING_POT.get()));
+		registration.addCraftingStation(FDRecipeTypes.CUTTING, new ItemStack(ModItems.CUTTING_BOARD.get()));
+		registration.addCraftingStation(RecipeTypes.CAMPFIRE_COOKING, new ItemStack(ModItems.STOVE.get()));
+		registration.addCraftingStation(RecipeTypes.CAMPFIRE_COOKING, new ItemStack(ModItems.SKILLET.get()));
+		registration.addCraftingStation(FDRecipeTypes.DECOMPOSITION, new ItemStack(ModBlocks.ORGANIC_COMPOST.get()));
+	}
+
+	@Override
+	public void registerGuiHandlers(IGuiHandlerRegistration registration) {
+		registration.addRecipeClickArea(CookingPotScreen.class, 89, 25, 24, 17, FDRecipeTypes.COOKING);
+	}
+
+	@Override
+	public void registerRecipeTransferHandlers(IRecipeTransferRegistration registration) {
+		registration.addRecipeTransferHandler(CookingPotMenu.class, ModMenuTypes.COOKING_POT.get(), FDRecipeTypes.COOKING, 0, 6, 9, 36);
+	}
+
+	@Override
+	public ResourceLocation getPluginUid() {
+		return ID;
+	}
+}

--- a/src/main/java/vectorwing/farmersdelight/integration/jei/category/CookingRecipeCategory.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/jei/category/CookingRecipeCategory.java
@@ -1,135 +1,127 @@
-// TODO: Reupdate when JEI updates.
-//package vectorwing.farmersdelight.integration.jei.category;
-//
-//import mezz.jei.api.constants.VanillaTypes;
-//import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
-//import mezz.jei.api.gui.drawable.IDrawable;
-//import mezz.jei.api.gui.drawable.IDrawableAnimated;
-//import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
-//import mezz.jei.api.helpers.IGuiHelper;
-//import mezz.jei.api.recipe.IFocusGroup;
-//import mezz.jei.api.recipe.RecipeIngredientRole;
-//import mezz.jei.api.recipe.RecipeType;
-//import mezz.jei.api.recipe.category.IRecipeCategory;
-//import net.minecraft.MethodsReturnNonnullByDefault;
-//import net.minecraft.client.gui.GuiGraphics;
-//import net.minecraft.core.NonNullList;
-//import net.minecraft.network.chat.Component;
-//import net.minecraft.resources.ResourceLocation;
-//import net.minecraft.world.item.ItemStack;
-//import net.minecraft.world.item.crafting.Ingredient;
-//import net.minecraft.world.item.crafting.RecipeHolder;
-//import vectorwing.farmersdelight.FarmersDelight;
-//import vectorwing.farmersdelight.common.crafting.CookingPotRecipe;
-//import vectorwing.farmersdelight.common.registry.ModItems;
-//import vectorwing.farmersdelight.common.utility.ClientRenderUtils;
-//import vectorwing.farmersdelight.common.utility.RecipeUtils;
-//import vectorwing.farmersdelight.common.utility.TextUtils;
-//import vectorwing.farmersdelight.integration.jei.FDRecipeTypes;
-//
-//import java.util.ArrayList;
-//import java.util.Arrays;
-//import java.util.Collections;
-//import java.util.List;
-//
-//@MethodsReturnNonnullByDefault
-//public class CookingRecipeCategory implements IRecipeCategory<RecipeHolder<CookingPotRecipe>>
-//{
-//	protected final IDrawable heatIndicator;
-//	protected final IDrawable timeIcon;
-//	protected final IDrawable expIcon;
-//	protected final IDrawableAnimated arrow;
-//	private final Component title;
-//	private final IDrawable background;
-//	private final IDrawable icon;
-//
-//	public CookingRecipeCategory(IGuiHelper helper) {
-//		title = TextUtils.getTranslation("jei.cooking");
-//		ResourceLocation backgroundImage = ResourceLocation.fromNamespaceAndPath(FarmersDelight.MODID, "textures/gui/cooking_pot.png");
-//		background = helper.createDrawable(backgroundImage, 29, 16, 116, 56);
-//		icon = helper.createDrawableIngredient(VanillaTypes.ITEM_STACK, new ItemStack(ModItems.COOKING_POT.get()));
-//		heatIndicator = helper.createDrawable(backgroundImage, 176, 0, 17, 15);
-//		timeIcon = helper.createDrawable(backgroundImage, 176, 32, 8, 11);
-//		expIcon = helper.createDrawable(backgroundImage, 176, 43, 9, 9);
-//		arrow = helper.drawableBuilder(backgroundImage, 176, 15, 24, 17)
-//				.buildAnimated(200, IDrawableAnimated.StartDirection.LEFT, false);
-//	}
-//
-//	@Override
-//	public RecipeType<RecipeHolder<CookingPotRecipe>> getRecipeType() {
-//		return FDRecipeTypes.COOKING;
-//	}
-//
-//	@Override
-//	public Component getTitle() {
-//		return this.title;
-//	}
-//
-//	@Override
-//	public IDrawable getBackground() {
-//		return this.background;
-//	}
-//
-//	@Override
-//	public IDrawable getIcon() {
-//		return this.icon;
-//	}
-//
-//	@Override
-//	public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<CookingPotRecipe> holder, IFocusGroup focusGroup) {
-//		CookingPotRecipe recipe = holder.value();
-//		NonNullList<Ingredient> recipeIngredients = recipe.getIngredients();
-//		ItemStack resultStack = RecipeUtils.getResultItem(recipe);
-//		ItemStack containerStack = recipe.getOutputContainer();
-//
-//		int borderSlotSize = 18;
-//		for (int row = 0; row < 2; ++row) {
-//			for (int column = 0; column < 3; ++column) {
-//				int inputIndex = row * 3 + column;
-//				if (inputIndex < recipeIngredients.size()) {
-//					builder.addSlot(RecipeIngredientRole.INPUT, (column * borderSlotSize) + 1, (row * borderSlotSize) + 1)
-//							.addItemStacks(Arrays.asList(recipeIngredients.get(inputIndex).getItems()));
-//				}
-//			}
-//		}
-//
-//		builder.addSlot(RecipeIngredientRole.OUTPUT, 95, 10).addItemStack(resultStack);
-//
-//		if (!containerStack.isEmpty()) {
-//			builder.addSlot(RecipeIngredientRole.CATALYST, 63, 39).addItemStack(containerStack);
-//		}
-//
-//		builder.addSlot(RecipeIngredientRole.OUTPUT, 95, 39).addItemStack(resultStack);
-//	}
-//
-//	@Override
-//	public void draw(RecipeHolder<CookingPotRecipe> holder, IRecipeSlotsView recipeSlotsView, GuiGraphics guiGraphics, double mouseX, double mouseY) {
-//		arrow.draw(guiGraphics, 60, 9);
-//		heatIndicator.draw(guiGraphics, 18, 39);
-//		timeIcon.draw(guiGraphics, 64, 2);
-//		if (holder.value().getExperience() > 0) {
-//			expIcon.draw(guiGraphics, 63, 21);
-//		}
-//	}
-//
-//	@Override
-//	public List<Component> getTooltipStrings(RecipeHolder<CookingPotRecipe> holder, IRecipeSlotsView recipeSlotsView, double mouseX, double mouseY) {
-//		CookingPotRecipe recipe = holder.value();
-//		if (ClientRenderUtils.isCursorInsideBounds(61, 2, 22, 28, mouseX, mouseY)) {
-//			List<Component> tooltipStrings = new ArrayList<>();
-//
-//			int cookTime = recipe.getCookTime();
-//			if (cookTime > 0) {
-//				int cookTimeSeconds = cookTime / 20;
-//				tooltipStrings.add(Component.translatable("gui.jei.category.smelting.time.seconds", cookTimeSeconds));
-//			}
-//			float experience = recipe.getExperience();
-//			if (experience > 0) {
-//				tooltipStrings.add(Component.translatable("gui.jei.category.smelting.experience", experience));
-//			}
-//
-//			return tooltipStrings;
-//		}
-//		return Collections.emptyList();
-//	}
-//}
+package vectorwing.farmersdelight.integration.jei.category;
+
+import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
+import mezz.jei.api.gui.builder.ITooltipBuilder;
+import mezz.jei.api.gui.drawable.IDrawable;
+import mezz.jei.api.gui.drawable.IDrawableAnimated;
+import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
+import mezz.jei.api.helpers.IGuiHelper;
+import mezz.jei.api.recipe.IFocusGroup;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import mezz.jei.api.recipe.category.IRecipeCategory;
+import mezz.jei.api.recipe.types.IRecipeType;
+import net.minecraft.MethodsReturnNonnullByDefault;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.RecipeHolder;
+import vectorwing.farmersdelight.FarmersDelight;
+import vectorwing.farmersdelight.common.crafting.CookingPotRecipe;
+import vectorwing.farmersdelight.common.registry.ModItems;
+import vectorwing.farmersdelight.common.utility.ClientRenderUtils;
+import vectorwing.farmersdelight.common.utility.TextUtils;
+import vectorwing.farmersdelight.integration.jei.FDRecipeTypes;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@MethodsReturnNonnullByDefault
+public class CookingRecipeCategory implements IRecipeCategory<RecipeHolder<CookingPotRecipe>>
+{
+	protected final IDrawable heatIndicator;
+	protected final IDrawable timeIcon;
+	protected final IDrawable expIcon;
+	protected final IDrawableAnimated arrow;
+	private final Component title;
+	private final IDrawable background;
+	private final IDrawable icon;
+
+	public CookingRecipeCategory(IGuiHelper helper) {
+		title = TextUtils.getTranslation("jei.cooking");
+		ResourceLocation backgroundImage = ResourceLocation.fromNamespaceAndPath(FarmersDelight.MODID, "textures/gui/cooking_pot.png");
+		background = helper.createDrawable(backgroundImage, 29, 16, 116, 56);
+		icon = helper.createDrawableIngredient(VanillaTypes.ITEM_STACK, new ItemStack(ModItems.COOKING_POT.get()));
+		heatIndicator = helper.createDrawable(backgroundImage, 176, 0, 17, 15);
+		timeIcon = helper.createDrawable(backgroundImage, 176, 32, 8, 11);
+		expIcon = helper.createDrawable(backgroundImage, 176, 43, 9, 9);
+		arrow = helper.drawableBuilder(backgroundImage, 176, 15, 24, 17)
+				.buildAnimated(200, IDrawableAnimated.StartDirection.LEFT, false);
+	}
+
+	@Override
+	public IRecipeType<RecipeHolder<CookingPotRecipe>> getRecipeType() {
+		return FDRecipeTypes.COOKING;
+	}
+
+	@Override
+	public Component getTitle() {
+		return this.title;
+	}
+
+	@Override
+	public IDrawable getBackground() {
+		return this.background;
+	}
+
+	@Override
+	public IDrawable getIcon() {
+		return this.icon;
+	}
+
+	@Override
+	public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<CookingPotRecipe> holder, IFocusGroup focusGroup) {
+		CookingPotRecipe recipe = holder.value();
+		List<Ingredient> recipeIngredients = recipe.input();
+		ItemStack resultStack = recipe.result();
+		ItemStack containerStack = recipe.container();
+
+		int borderSlotSize = 18;
+		for (int row = 0; row < 2; ++row) {
+			for (int column = 0; column < 3; ++column) {
+				int inputIndex = row * 3 + column;
+				if (inputIndex < recipeIngredients.size()) {
+					builder.addSlot(RecipeIngredientRole.INPUT, (column * borderSlotSize) + 1, (row * borderSlotSize) + 1)
+							.add(recipeIngredients.get(inputIndex));
+				}
+			}
+		}
+
+		builder.addSlot(RecipeIngredientRole.OUTPUT, 95, 10).add(resultStack);
+
+		if (!containerStack.isEmpty()) {
+			builder.addSlot(RecipeIngredientRole.CRAFTING_STATION, 63, 39).add(containerStack);
+		}
+
+		builder.addSlot(RecipeIngredientRole.OUTPUT, 95, 39).add(resultStack);
+	}
+
+	@Override
+	public void draw(RecipeHolder<CookingPotRecipe> holder, IRecipeSlotsView recipeSlotsView, GuiGraphics guiGraphics, double mouseX, double mouseY) {
+		arrow.draw(guiGraphics, 60, 9);
+		heatIndicator.draw(guiGraphics, 18, 39);
+		timeIcon.draw(guiGraphics, 64, 2);
+		if (holder.value().getExperience() > 0) {
+			expIcon.draw(guiGraphics, 63, 21);
+		}
+	}
+
+	@Override
+	public void getTooltip(ITooltipBuilder tooltipBuilder, RecipeHolder<CookingPotRecipe> holder, IRecipeSlotsView recipeSlotsView, double mouseX, double mouseY) {
+		CookingPotRecipe recipe = holder.value();
+		if (ClientRenderUtils.isCursorInsideBounds(61, 2, 22, 28, mouseX, mouseY)) {
+			int cookTime = recipe.getCookTime();
+			if (cookTime > 0) {
+				int cookTimeSeconds = cookTime / 20;
+				tooltipBuilder.add(Component.translatable("gui.jei.category.smelting.time.seconds", cookTimeSeconds));
+			}
+			float experience = recipe.getExperience();
+			if (experience > 0) {
+                tooltipBuilder.add(Component.translatable("gui.jei.category.smelting.experience", experience));
+			}
+		}
+	}
+}

--- a/src/main/java/vectorwing/farmersdelight/integration/jei/category/CuttingRecipeCategory.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/jei/category/CuttingRecipeCategory.java
@@ -1,117 +1,117 @@
-// TODO: Reupdate when JEI updates.
-//package vectorwing.farmersdelight.integration.jei.category;
-//
-//import mezz.jei.api.constants.VanillaTypes;
-//import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
-//import mezz.jei.api.gui.drawable.IDrawable;
-//import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
-//import mezz.jei.api.helpers.IGuiHelper;
-//import mezz.jei.api.recipe.IFocusGroup;
-//import mezz.jei.api.recipe.RecipeIngredientRole;
-//import mezz.jei.api.recipe.RecipeType;
-//import mezz.jei.api.recipe.category.IRecipeCategory;
-//import net.minecraft.ChatFormatting;
-//import net.minecraft.MethodsReturnNonnullByDefault;
-//import net.minecraft.client.gui.GuiGraphics;
-//import net.minecraft.core.NonNullList;
-//import net.minecraft.network.chat.Component;
-//import net.minecraft.resources.ResourceLocation;
-//import net.minecraft.world.item.ItemStack;
-//import net.minecraft.world.item.crafting.RecipeHolder;
-//import vectorwing.farmersdelight.FarmersDelight;
-//import vectorwing.farmersdelight.common.crafting.CuttingBoardRecipe;
-//import vectorwing.farmersdelight.common.crafting.ingredient.ChanceResult;
-//import vectorwing.farmersdelight.common.registry.ModItems;
-//import vectorwing.farmersdelight.common.utility.TextUtils;
-//import vectorwing.farmersdelight.integration.jei.FDRecipeTypes;
-//
-//@MethodsReturnNonnullByDefault
-//public class CuttingRecipeCategory implements IRecipeCategory<RecipeHolder<CuttingBoardRecipe>>
-//{
-//	public static final int OUTPUT_GRID_X = 76;
-//	public static final int OUTPUT_GRID_Y = 10;
-//	private final IDrawable slot;
-//	private final IDrawable slotChance;
-//	private final Component title;
-//	private final IDrawable background;
-//	private final IDrawable icon;
-//
-//	public CuttingRecipeCategory(IGuiHelper helper) {
-//		title = TextUtils.getTranslation("jei.cutting");
-//		ResourceLocation backgroundImage = ResourceLocation.fromNamespaceAndPath(FarmersDelight.MODID, "textures/gui/jei/cutting_board.png");
-//		slot = helper.createDrawable(backgroundImage, 0, 58, 18, 18);
-//		slotChance = helper.createDrawable(backgroundImage, 18, 58, 18, 18);
-//		background = helper.createDrawable(backgroundImage, 0, 0, 117, 57);
-//		icon = helper.createDrawableIngredient(VanillaTypes.ITEM_STACK, new ItemStack(ModItems.CUTTING_BOARD.get()));
-//	}
-//
-//	@Override
-//	public RecipeType<RecipeHolder<CuttingBoardRecipe>> getRecipeType() {
-//		return FDRecipeTypes.CUTTING;
-//	}
-//
-//	@Override
-//	public Component getTitle() {
-//		return this.title;
-//	}
-//
-//	@Override
-//	public IDrawable getBackground() {
-//		return this.background;
-//	}
-//
-//	@Override
-//	public IDrawable getIcon() {
-//		return this.icon;
-//	}
-//
-//	@Override
-//	public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<CuttingBoardRecipe> holder, IFocusGroup focusGroup) {
-//		CuttingBoardRecipe recipe = holder.value();
-//		builder.addSlot(RecipeIngredientRole.INPUT, 16, 8).addIngredients(recipe.getTool());
-//		builder.addSlot(RecipeIngredientRole.INPUT, 16, 27).addIngredients(recipe.getIngredients().get(0));
-//
-//		NonNullList<ChanceResult> recipeOutputs = recipe.getRollableResults();
-//
-//		int size = recipeOutputs.size();
-//		int centerX = size > 1 ? 1 : 10;
-//		int centerY = size > 2 ? 1 : 10;
-//
-//		for (int i = 0; i < size; i++) {
-//			int xOffset = centerX + (i % 2 == 0 ? 0 : 19);
-//			int yOffset = centerY + ((i / 2) * 19);
-//
-//			int index = i;
-//			builder.addSlot(RecipeIngredientRole.OUTPUT, OUTPUT_GRID_X + xOffset, OUTPUT_GRID_Y + yOffset)
-//					.addItemStack(recipeOutputs.get(i).stack())
-//					.addTooltipCallback((slotView, tooltip) -> {
-//						ChanceResult output = recipeOutputs.get(index);
-//						float chance = output.chance();
-//						if (chance != 1)
-//							tooltip.add(1, TextUtils.getTranslation("jei.chance", chance < 0.01 ? "<1" : (int) (chance * 100))
-//									.withStyle(ChatFormatting.GOLD));
-//					});
-//		}
-//	}
-//
-//	@Override
-//	public void draw(RecipeHolder<CuttingBoardRecipe> holder, IRecipeSlotsView recipeSlotsView, GuiGraphics guiGraphics, double mouseX, double mouseY) {
-//		CuttingBoardRecipe recipe = holder.value();
-//		NonNullList<ChanceResult> recipeOutputs = recipe.getRollableResults();
-//
-//		int size = recipe.getResults().size();
-//		int centerX = size > 1 ? 0 : 9;
-//		int centerY = size > 2 ? 0 : 9;
-//
-//		for (int i = 0; i < size; i++) {
-//			int xOffset = centerX + (i % 2 == 0 ? 0 : 19);
-//			int yOffset = centerY + ((i / 2) * 19);
-//
-//			if (recipeOutputs.get(i).chance() != 1) {
-//				slotChance.draw(guiGraphics, OUTPUT_GRID_X + xOffset, OUTPUT_GRID_Y + yOffset);
-//			} else {
-//				slot.draw(guiGraphics, OUTPUT_GRID_X + xOffset, OUTPUT_GRID_Y + yOffset);
-//			}
-//		}
-//	}
-//}
+package vectorwing.farmersdelight.integration.jei.category;
+
+import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
+import mezz.jei.api.gui.drawable.IDrawable;
+import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
+import mezz.jei.api.helpers.IGuiHelper;
+import mezz.jei.api.recipe.IFocusGroup;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import mezz.jei.api.recipe.category.IRecipeCategory;
+import mezz.jei.api.recipe.types.IRecipeType;
+import net.minecraft.ChatFormatting;
+import net.minecraft.MethodsReturnNonnullByDefault;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
+import vectorwing.farmersdelight.FarmersDelight;
+import vectorwing.farmersdelight.common.crafting.CuttingBoardRecipe;
+import vectorwing.farmersdelight.common.crafting.ingredient.ChanceResult;
+import vectorwing.farmersdelight.common.registry.ModItems;
+import vectorwing.farmersdelight.common.utility.TextUtils;
+import vectorwing.farmersdelight.integration.jei.FDRecipeTypes;
+
+import java.util.List;
+
+@MethodsReturnNonnullByDefault
+public class CuttingRecipeCategory implements IRecipeCategory<RecipeHolder<CuttingBoardRecipe>>
+{
+	public static final int OUTPUT_GRID_X = 76;
+	public static final int OUTPUT_GRID_Y = 10;
+	private final IDrawable slot;
+	private final IDrawable slotChance;
+	private final Component title;
+	private final IDrawable background;
+	private final IDrawable icon;
+
+	public CuttingRecipeCategory(IGuiHelper helper) {
+		title = TextUtils.getTranslation("jei.cutting");
+		ResourceLocation backgroundImage = ResourceLocation.fromNamespaceAndPath(FarmersDelight.MODID, "textures/gui/jei/cutting_board.png");
+		slot = helper.createDrawable(backgroundImage, 0, 58, 18, 18);
+		slotChance = helper.createDrawable(backgroundImage, 18, 58, 18, 18);
+		background = helper.createDrawable(backgroundImage, 0, 0, 117, 57);
+		icon = helper.createDrawableIngredient(VanillaTypes.ITEM_STACK, new ItemStack(ModItems.CUTTING_BOARD.get()));
+	}
+
+	@Override
+	public IRecipeType<RecipeHolder<CuttingBoardRecipe>> getRecipeType() {
+		return FDRecipeTypes.CUTTING;
+	}
+
+	@Override
+	public Component getTitle() {
+		return this.title;
+	}
+
+	@Override
+	public IDrawable getBackground() {
+		return this.background;
+	}
+
+	@Override
+	public IDrawable getIcon() {
+		return this.icon;
+	}
+
+	@Override
+	public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<CuttingBoardRecipe> holder, IFocusGroup focusGroup) {
+		CuttingBoardRecipe recipe = holder.value();
+		builder.addSlot(RecipeIngredientRole.INPUT, 16, 8).add(recipe.getTool());
+		builder.addSlot(RecipeIngredientRole.INPUT, 16, 27).add(recipe.getInput());
+
+		List<ChanceResult> recipeOutputs = recipe.getRollableResults();
+
+		int size = recipeOutputs.size();
+		int centerX = size > 1 ? 1 : 10;
+		int centerY = size > 2 ? 1 : 10;
+
+		for (int i = 0; i < size; i++) {
+			int xOffset = centerX + (i % 2 == 0 ? 0 : 19);
+			int yOffset = centerY + ((i / 2) * 19);
+
+			int index = i;
+			builder.addSlot(RecipeIngredientRole.OUTPUT, OUTPUT_GRID_X + xOffset, OUTPUT_GRID_Y + yOffset)
+					.add(recipeOutputs.get(i).stack())
+					.addTooltipCallback((slotView, tooltip) -> {
+						ChanceResult output = recipeOutputs.get(index);
+						float chance = output.chance();
+						if (chance != 1)
+							tooltip.add(1, TextUtils.getTranslation("jei.chance", chance < 0.01 ? "<1" : (int) (chance * 100))
+									.withStyle(ChatFormatting.GOLD));
+					});
+		}
+	}
+
+	@Override
+	public void draw(RecipeHolder<CuttingBoardRecipe> holder, IRecipeSlotsView recipeSlotsView, GuiGraphics guiGraphics, double mouseX, double mouseY) {
+		CuttingBoardRecipe recipe = holder.value();
+		List<ChanceResult> recipeOutputs = recipe.getRollableResults();
+
+		int size = recipe.getResults().size();
+		int centerX = size > 1 ? 0 : 9;
+		int centerY = size > 2 ? 0 : 9;
+
+		for (int i = 0; i < size; i++) {
+			int xOffset = centerX + (i % 2 == 0 ? 0 : 19);
+			int yOffset = centerY + ((i / 2) * 19);
+
+			if (recipeOutputs.get(i).chance() != 1) {
+				slotChance.draw(guiGraphics, OUTPUT_GRID_X + xOffset, OUTPUT_GRID_Y + yOffset);
+			} else {
+				slot.draw(guiGraphics, OUTPUT_GRID_X + xOffset, OUTPUT_GRID_Y + yOffset);
+			}
+		}
+	}
+}

--- a/src/main/java/vectorwing/farmersdelight/integration/jei/category/DecompositionRecipeCategory.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/jei/category/DecompositionRecipeCategory.java
@@ -1,110 +1,106 @@
-// TODO: Reupdate when JEI updates.
-//package vectorwing.farmersdelight.integration.jei.category;
+package vectorwing.farmersdelight.integration.jei.category;
 
-//import mezz.jei.api.constants.VanillaTypes;
-//import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
-//import mezz.jei.api.gui.builder.ITooltipBuilder;
-//import mezz.jei.api.gui.drawable.IDrawable;
-//import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
-//import mezz.jei.api.helpers.IGuiHelper;
-//import mezz.jei.api.recipe.IFocusGroup;
-//import mezz.jei.api.recipe.RecipeIngredientRole;
-//import mezz.jei.api.recipe.RecipeType;
-//import mezz.jei.api.recipe.category.IRecipeCategory;
-//import net.minecraft.MethodsReturnNonnullByDefault;
-//import net.minecraft.client.gui.GuiGraphics;
-//import net.minecraft.core.registries.BuiltInRegistries;
-//import net.minecraft.network.chat.Component;
-//import net.minecraft.network.chat.MutableComponent;
-//import net.minecraft.resources.ResourceLocation;
-//import net.minecraft.world.item.ItemStack;
-//import org.jetbrains.annotations.NotNull;
-//import vectorwing.farmersdelight.FarmersDelight;
-//import vectorwing.farmersdelight.common.registry.ModBlocks;
-//import vectorwing.farmersdelight.common.registry.ModItems;
-//import vectorwing.farmersdelight.common.tag.ModTags;
-//import vectorwing.farmersdelight.common.utility.ClientRenderUtils;
-//import vectorwing.farmersdelight.common.utility.TextUtils;
-//import vectorwing.farmersdelight.integration.jei.FDRecipeTypes;
-//import vectorwing.farmersdelight.integration.jei.resource.DecompositionDummy;
+import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
+import mezz.jei.api.gui.builder.ITooltipBuilder;
+import mezz.jei.api.gui.drawable.IDrawable;
+import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
+import mezz.jei.api.helpers.IGuiHelper;
+import mezz.jei.api.recipe.IFocusGroup;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import mezz.jei.api.recipe.category.IRecipeCategory;
+import mezz.jei.api.recipe.types.IRecipeType;
+import net.minecraft.MethodsReturnNonnullByDefault;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import vectorwing.farmersdelight.FarmersDelight;
+import vectorwing.farmersdelight.common.registry.ModBlocks;
+import vectorwing.farmersdelight.common.registry.ModItems;
+import vectorwing.farmersdelight.common.tag.ModTags;
+import vectorwing.farmersdelight.common.utility.ClientRenderUtils;
+import vectorwing.farmersdelight.common.utility.TextUtils;
+import vectorwing.farmersdelight.integration.jei.FDRecipeTypes;
+import vectorwing.farmersdelight.integration.jei.resource.DecompositionDummy;
 
-//import java.util.ArrayList;
-//import java.util.List;
+import java.util.ArrayList;
+import java.util.List;
 
-//@MethodsReturnNonnullByDefault
-//public class DecompositionRecipeCategory implements IRecipeCategory<DecompositionDummy> {
-//    public static final ResourceLocation UID = ResourceLocation.fromNamespaceAndPath(FarmersDelight.MODID, "decomposition");
-//    private static final int slotSize = 22;
+@MethodsReturnNonnullByDefault
+public class DecompositionRecipeCategory implements IRecipeCategory<DecompositionDummy> {
+    public static final ResourceLocation UID = ResourceLocation.fromNamespaceAndPath(FarmersDelight.MODID, "decomposition");
+    private static final int slotSize = 22;
 
-//    private final Component title;
-//    private final IDrawable background;
-//    private final IDrawable slotIcon;
-//    private final IDrawable icon;
-//    private final ItemStack organicCompost;
-//    private final ItemStack richSoil;
+    private final Component title;
+    private final IDrawable background;
+    private final IDrawable slotIcon;
+    private final IDrawable icon;
+    private final ItemStack organicCompost;
+    private final ItemStack richSoil;
 
-//    public DecompositionRecipeCategory(IGuiHelper helper) {
-//        title = TextUtils.getTranslation("jei.decomposition");
-//        ResourceLocation backgroundImage = ResourceLocation.fromNamespaceAndPath(FarmersDelight.MODID, "textures/gui/jei/decomposition.png");
-//        background = helper.createDrawable(backgroundImage, 0, 0, 118, 80);
-//        organicCompost = new ItemStack(ModBlocks.ORGANIC_COMPOST.get());
-//        richSoil = new ItemStack(ModItems.RICH_SOIL.get());
-//        icon = helper.createDrawableIngredient(VanillaTypes.ITEM_STACK, richSoil);
-//        slotIcon = helper.createDrawable(backgroundImage, 119, 0, slotSize, slotSize);
-//    }
+    public DecompositionRecipeCategory(IGuiHelper helper) {
+        title = TextUtils.getTranslation("jei.decomposition");
+        ResourceLocation backgroundImage = ResourceLocation.fromNamespaceAndPath(FarmersDelight.MODID, "textures/gui/jei/decomposition.png");
+        background = helper.createDrawable(backgroundImage, 0, 0, 118, 80);
+        organicCompost = new ItemStack(ModBlocks.ORGANIC_COMPOST.get());
+        richSoil = new ItemStack(ModItems.RICH_SOIL.get());
+        icon = helper.createDrawableIngredient(VanillaTypes.ITEM_STACK, richSoil);
+        slotIcon = helper.createDrawable(backgroundImage, 119, 0, slotSize, slotSize);
+    }
 
-//    @Override
-//    public RecipeType<DecompositionDummy> getRecipeType() {
-//        return FDRecipeTypes.DECOMPOSITION;
-//    }
+    @Override
+    public IRecipeType<DecompositionDummy> getRecipeType() {
+        return FDRecipeTypes.DECOMPOSITION;
+    }
 
-//    @Override
-//    public Component getTitle() {
-//        return this.title;
-//    }
+    @Override
+    public Component getTitle() {
+        return this.title;
+    }
 
-//    @Override
-//    public IDrawable getBackground() {
-//        return this.background;
-//    }
+    @Override
+    public IDrawable getBackground() {
+        return this.background;
+    }
 
-//    @Override
-//    public IDrawable getIcon() {
-//        return this.icon;
-//    }
+    @Override
+    public IDrawable getIcon() {
+        return this.icon;
+    }
 
-//    @Override
-//    public void setRecipe(IRecipeLayoutBuilder builder, DecompositionDummy recipe, IFocusGroup focusGroup) {
-//        List<ItemStack> accelerators = new ArrayList<>();
-//        BuiltInRegistries.BLOCK.getTag(ModTags.COMPOST_ACTIVATORS).ifPresent(s -> s.forEach(f -> accelerators.add(new ItemStack(f.value()))));
+    @Override
+    public void setRecipe(IRecipeLayoutBuilder builder, DecompositionDummy recipe, IFocusGroup focusGroup) {
+        List<ItemStack> accelerators = new ArrayList<>();
+        BuiltInRegistries.BLOCK.get(ModTags.COMPOST_ACTIVATORS).ifPresent(s -> s.forEach(f -> accelerators.add(new ItemStack(f.value()))));
 
-//        builder.addSlot(RecipeIngredientRole.INPUT, 9, 26).addItemStack(organicCompost);
-//        builder.addSlot(RecipeIngredientRole.OUTPUT, 93, 26).addItemStack(richSoil);
-//        builder.addSlot(RecipeIngredientRole.RENDER_ONLY, 64, 54).addItemStacks(accelerators);
-//    }
+        builder.addSlot(RecipeIngredientRole.INPUT, 9, 26).add(organicCompost);
+        builder.addSlot(RecipeIngredientRole.OUTPUT, 93, 26).add(richSoil);
+        builder.addSlot(RecipeIngredientRole.RENDER_ONLY, 64, 54).addItemStacks(accelerators);
+    }
 
-//    @Override
-//    public void draw(DecompositionDummy recipe, IRecipeSlotsView recipeSlotsView, GuiGraphics guiGraphics, double mouseX, double mouseY) {
-//        this.slotIcon.draw(guiGraphics, 63, 53);
-//    }
+    @Override
+    public void draw(DecompositionDummy recipe, IRecipeSlotsView recipeSlotsView, GuiGraphics guiGraphics, double mouseX, double mouseY) {
+        this.slotIcon.draw(guiGraphics, 63, 53);
+    }
 
-//    @Override
-//    public void getTooltip(ITooltipBuilder tooltip, DecompositionDummy recipe, IRecipeSlotsView recipeSlotsView, double mouseX, double mouseY) {
-//        if (ClientRenderUtils.isCursorInsideBounds(40, 38, 11, 11, mouseX, mouseY)) {
-//            tooltip.add(translateKey(".light"));
-//            return;
-//        }
-//        if (ClientRenderUtils.isCursorInsideBounds(53, 38, 11, 11, mouseX, mouseY)) {
-//            tooltip.add(translateKey(".fluid"));
-//            return;
-//        }
-//        if (ClientRenderUtils.isCursorInsideBounds(67, 38, 11, 11, mouseX, mouseY)) {
-//            tooltip.add(translateKey(".accelerators"));
-//            return;
-//        }
-//    }
+    @Override
+    public void getTooltip(ITooltipBuilder tooltip, DecompositionDummy recipe, IRecipeSlotsView recipeSlotsView, double mouseX, double mouseY) {
+        if (ClientRenderUtils.isCursorInsideBounds(40, 38, 11, 11, mouseX, mouseY)) {
+            tooltip.add(translateKey(".light"));
+        }
+        if (ClientRenderUtils.isCursorInsideBounds(53, 38, 11, 11, mouseX, mouseY)) {
+            tooltip.add(translateKey(".fluid"));
+        }
+        if (ClientRenderUtils.isCursorInsideBounds(67, 38, 11, 11, mouseX, mouseY)) {
+            tooltip.add(translateKey(".accelerators"));
+        }
+    }
 
-//    private static MutableComponent translateKey(@NotNull String suffix) {
-//        return Component.translatable(FarmersDelight.MODID + ".jei.decomposition" + suffix);
-//    }
-//}
+    private static MutableComponent translateKey(@NotNull String suffix) {
+        return Component.translatable(FarmersDelight.MODID + ".jei.decomposition" + suffix);
+    }
+}

--- a/src/main/java/vectorwing/farmersdelight/integration/jei/resource/CuttingBoardDrawable.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/jei/resource/CuttingBoardDrawable.java
@@ -1,54 +1,54 @@
-//package vectorwing.farmersdelight.integration.jei.resource;
-//
-//import com.mojang.blaze3d.vertex.PoseStack;
-//import mezz.jei.api.gui.drawable.IDrawable;
-//import net.minecraft.MethodsReturnNonnullByDefault;
-//import net.minecraft.client.Minecraft;
-//import net.minecraft.client.gui.GuiGraphics;
-//import net.minecraft.client.renderer.entity.ItemRenderer;
-//import net.minecraft.client.renderer.texture.TextureManager;
-//import net.minecraft.client.resources.model.BakedModel;
-//import net.minecraft.world.item.ItemStack;
-//import vectorwing.farmersdelight.common.utility.ClientRenderUtils;
-//
-//import javax.annotation.ParametersAreNonnullByDefault;
-//import java.util.function.Supplier;
-//
-//@ParametersAreNonnullByDefault
-//@MethodsReturnNonnullByDefault
-//public class CuttingBoardDrawable implements IDrawable
-//{
-//	private final Supplier<ItemStack> supplier;
-//	private ItemStack stack;
-//
-//	public CuttingBoardDrawable(Supplier<ItemStack> supplier) {
-//		this.supplier = supplier;
-//	}
-//
-//	@Override
-//	public int getWidth() {
-//		return 48;
-//	}
-//
-//	@Override
-//	public int getHeight() {
-//		return 48;
-//	}
-//
-//	@Override
-//	public void draw(GuiGraphics guiGraphics, int xOffset, int yOffset) {
-//		if (stack == null) {
-//			stack = supplier.get();
-//		}
-////		RenderSystem.pushMatrix();
-////		RenderSystem.multMatrix(matrixStack.last().pose());
-////		RenderSystem.enableDepthTest();
-////		Lighting.turnBackOn();
-////		RenderSystem.pushMatrix();
-////		RenderSystem.translated(xOffset, yOffset, 0);
-////		RenderSystem.pushMatrix();
-////		RenderSystem.translated(1, 1, 0);
-//
+package vectorwing.farmersdelight.integration.jei.resource;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import mezz.jei.api.gui.drawable.IDrawable;
+import net.minecraft.MethodsReturnNonnullByDefault;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.renderer.entity.ItemRenderer;
+import net.minecraft.client.renderer.texture.TextureManager;
+import net.minecraft.world.item.ItemStack;
+import vectorwing.farmersdelight.common.utility.ClientRenderUtils;
+
+
+import java.util.function.Supplier;
+
+
+@MethodsReturnNonnullByDefault
+public class CuttingBoardDrawable implements IDrawable
+{
+	private final Supplier<ItemStack> supplier;
+	private ItemStack stack;
+
+	public CuttingBoardDrawable(Supplier<ItemStack> supplier) {
+		this.supplier = supplier;
+	}
+
+	@Override
+	public int getWidth() {
+		return 48;
+	}
+
+	@Override
+	public int getHeight() {
+		return 48;
+	}
+
+	@Override
+	public void draw(GuiGraphics guiGraphics, int xOffset, int yOffset) {
+        //FIXME
+		if (stack == null) {
+			stack = supplier.get();
+		}
+//		RenderSystem.pushMatrix();
+//		RenderSystem.multMatrix(matrixStack.last().pose());
+//		RenderSystem.enableDepthTest();
+//		Lighting.turnBackOn();
+//		RenderSystem.pushMatrix();
+//		RenderSystem.translated(xOffset, yOffset, 0);
+//		RenderSystem.pushMatrix();
+//		RenderSystem.translated(1, 1, 0);
+
 //		Minecraft minecraft = Minecraft.getInstance();
 //		ItemRenderer itemRenderer = minecraft.getItemRenderer();
 //		itemRenderer.blitOffset += 50.0F;
@@ -56,11 +56,11 @@
 //		TextureManager textureManager = Minecraft.getInstance().textureManager;
 //		ClientRenderUtils.renderItemIntoGUIScalable(stack, 48.0F, 48.0F, bakedmodel, itemRenderer, textureManager);
 //		itemRenderer.blitOffset -= 50.0F;
-//
-////		RenderSystem.popMatrix();
-////		RenderSystem.popMatrix();
-////		RenderSystem.disableBlend();
-////		Lighting.turnOff();
-////		RenderSystem.popMatrix();
-//	}
-//}
+
+//		RenderSystem.popMatrix();
+//		RenderSystem.popMatrix();
+//		RenderSystem.disableBlend();
+//		Lighting.turnOff();
+//		RenderSystem.popMatrix();
+	}
+}

--- a/src/main/java/vectorwing/farmersdelight/integration/jei/resource/CuttingBoardDrawable.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/jei/resource/CuttingBoardDrawable.java
@@ -36,7 +36,7 @@ public class CuttingBoardDrawable implements IDrawable
 
 	@Override
 	public void draw(GuiGraphics guiGraphics, int xOffset, int yOffset) {
-        //FIXME
+        //FIXME - unused?
 		if (stack == null) {
 			stack = supplier.get();
 		}

--- a/src/main/java/vectorwing/farmersdelight/integration/jei/resource/CuttingBoardDrawable.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/jei/resource/CuttingBoardDrawable.java
@@ -1,14 +1,9 @@
 package vectorwing.farmersdelight.integration.jei.resource;
 
-import com.mojang.blaze3d.vertex.PoseStack;
 import mezz.jei.api.gui.drawable.IDrawable;
 import net.minecraft.MethodsReturnNonnullByDefault;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.renderer.entity.ItemRenderer;
-import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.world.item.ItemStack;
-import vectorwing.farmersdelight.common.utility.ClientRenderUtils;
 
 
 import java.util.function.Supplier;

--- a/src/main/java/vectorwing/farmersdelight/integration/jei/resource/DoughRecipeMaker.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/jei/resource/DoughRecipeMaker.java
@@ -1,29 +1,31 @@
-// TODO: Reupdate when JEI updates.
-//package vectorwing.farmersdelight.integration.jei.resource;
-//
-//import net.minecraft.core.NonNullList;
-//import net.minecraft.resources.ResourceLocation;
-//import net.minecraft.world.item.ItemStack;
-//import net.minecraft.world.item.Items;
-//import net.minecraft.world.item.crafting.*;
-//import vectorwing.farmersdelight.FarmersDelight;
-//import vectorwing.farmersdelight.common.registry.ModItems;
-//
-//import java.util.List;
-//
-//public class DoughRecipeMaker
-//{
-//	public static List<RecipeHolder<CraftingRecipe>> createRecipe() {
-//		NonNullList<Ingredient> inputs = NonNullList.of(
-//				Ingredient.EMPTY,
-//				Ingredient.of(Items.WHEAT),
-//				Ingredient.of(Items.WATER_BUCKET)
-//		);
-//
-//		ItemStack output = new ItemStack(ModItems.WHEAT_DOUGH.get());
-//		String path = FarmersDelight.MODID + ".dough";
-//
-//		ResourceLocation id = ResourceLocation.parse(path);
-//		return List.of(new RecipeHolder<>(id, new ShapelessRecipe(path, CraftingBookCategory.MISC, output, inputs)));
-//	}
-//}
+package vectorwing.farmersdelight.integration.jei.resource;
+
+import net.minecraft.core.NonNullList;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.crafting.*;
+import vectorwing.farmersdelight.FarmersDelight;
+import vectorwing.farmersdelight.common.registry.ModItems;
+
+import java.util.List;
+
+public class DoughRecipeMaker
+{
+	public static List<RecipeHolder<CraftingRecipe>> createRecipe() {
+		NonNullList<Ingredient> inputs = NonNullList.of(
+                // This was an empty stack, but JEI complained, and it isn't visible anyway..
+				Ingredient.of(Items.WHEAT),
+				Ingredient.of(Items.WHEAT),
+				Ingredient.of(Items.WATER_BUCKET)
+		);
+
+		ItemStack output = new ItemStack(ModItems.WHEAT_DOUGH.get());
+		String path = FarmersDelight.MODID + ".dough";
+
+		ResourceLocation id = ResourceLocation.parse(path);
+		return List.of(new RecipeHolder<>(ResourceKey.create(Registries.RECIPE, id), new ShapelessRecipe(path, CraftingBookCategory.MISC, output, inputs)));
+	}
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,6 +30,9 @@
     "mm:early_risers": [
       "vectorwing.farmersdelight.refabricated.FarmersDelightASM"
     ],
+    "jei_mod_plugin": [
+      "vectorwing.farmersdelight.integration.jei.JEIPlugin"
+    ],
     "rei_client": [
       "vectorwing.farmersdelight.integration.rei.client.ClientREIPlugin"
     ],
@@ -50,7 +53,7 @@
   "accessWidener": "${mod_id}.accesswidener",
   "depends": {
     "fabricloader": ">=0.16",
-    "fabric-api": "*",
+    "fabric-api": ">=0.137.0",
     "minecraft": "${minecraft_required}"
   }
 }


### PR DESCRIPTION
- Re-enables JEI integration, which bumps the mod's required dependencies to the first version of Fabric API that includes the Recipe Sync API and the latest version of Loom, which JEI requires.
- Currently, I've been unable to set up Farmer's Delight Refabricated's recipe serializer to sync with the Recipe Sync API - the Ingredient codec that they're using is somehow containing air. Haven't been able to debug it, but vanilla recipes serialize fine so I'm hoping its a bug with my implementation and not the API itself.

Feel free to use any of this if it helps, the stream codecs have thrown me for a loop.