### PR TITLE
Fixed Pies replenishing hunger twice when eating them directly

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/common/block/PieBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/PieBlock.java
@@ -97,11 +97,9 @@ public class PieBlock extends Block
 			return InteractionResult.PASS;
 		} else {
 			ItemStack sliceStack = this.getPieSliceItem();
-			FoodProperties sliceFood = sliceStack.get(DataComponents.FOOD);
-			Consumable sliceConsumable = sliceStack.get(DataComponents.CONSUMABLE);
 
-			if (sliceFood != null) {
-				playerIn.getFoodData().eat(sliceFood);
+			if (sliceStack.has(DataComponents.FOOD)) {
+				Consumable sliceConsumable = sliceStack.get(DataComponents.CONSUMABLE);
 				sliceStack.getAllOfType(ConsumableListener.class).forEach(consumableListener -> consumableListener.onConsume(level, playerIn, sliceStack, sliceConsumable));
 				if (!level.isClientSide()) {
 					sliceConsumable.onConsumeEffects().forEach(consumeEffect -> consumeEffect.apply(level, sliceStack, playerIn));


### PR DESCRIPTION
Simple fix for a bug with Pie Blocks replenishing hunger twice when you eat them directly by clicking the blocks (it gives 6 hunger points instead of 3 that pie slices should). It happens because in the next row there is a call of `onConsume` for every `ConsumableListener` component (including `FoodProperties`), which calls `getFoodData().eat` again