### PR TITLE
Fix colored canvas sign rendering

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/client/renderer/AbstractCanvasSignRenderer.java
+++ b/src/main/java/vectorwing/farmersdelight/client/renderer/AbstractCanvasSignRenderer.java
@@ -12,13 +12,18 @@ import net.minecraft.client.resources.model.sprite.SpriteGetter;
 import net.minecraft.client.resources.model.sprite.SpriteId;
 import net.minecraft.util.Unit;
 import net.minecraft.world.item.DyeColor;
+import net.minecraft.world.level.block.entity.SignBlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.WoodType;
+import net.minecraft.world.phys.Vec3;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import vectorwing.farmersdelight.client.renderer.state.CanvasSignRenderState;
+import vectorwing.farmersdelight.common.block.state.CanvasSign;
 
 // Vanilla copy of AbstractSignRenderer with WoodType replaced with DyeColor
 public abstract class AbstractCanvasSignRenderer<S extends CanvasSignRenderState> extends AbstractSignRenderer<S> {
+    @Nullable
     private static DyeColor capturedColor;
     private final SpriteGetter sprites;
 
@@ -27,11 +32,24 @@ public abstract class AbstractCanvasSignRenderer<S extends CanvasSignRenderState
         sprites = context.sprites();
     }
 
-    protected abstract SpriteId getSignSprite(DyeColor color);
+    protected abstract SpriteId getSignSprite(@Nullable DyeColor color);
 
     @Override
     protected SpriteId getSignSprite(@NonNull WoodType type) {
         throw new UnsupportedOperationException("Obtaining sign sprite from WoodType is unsupported by Canvas Signs");
+    }
+
+    @Override
+    public void extractRenderState(
+            final @NonNull SignBlockEntity blockEntity,
+            final S state,
+            final float partialTicks,
+            final @NonNull Vec3 cameraPosition,
+            final ModelFeatureRenderer.@Nullable CrumblingOverlay breakProgress
+    ) {
+        super.extractRenderState(blockEntity, state, partialTicks, cameraPosition, breakProgress);
+        BlockState blockState = blockEntity.getBlockState();
+        state.color = blockState.getBlock() instanceof CanvasSign canvasSign ? canvasSign.getBackgroundColor() : null;
     }
 
     public void submit(final S state, final @NonNull PoseStack poseStack, final @NonNull SubmitNodeCollector submitNodeCollector, final @NonNull CameraRenderState camera) {

--- a/src/main/java/vectorwing/farmersdelight/client/renderer/HangingCanvasSignRenderer.java
+++ b/src/main/java/vectorwing/farmersdelight/client/renderer/HangingCanvasSignRenderer.java
@@ -33,7 +33,7 @@ public class HangingCanvasSignRenderer extends AbstractCanvasSignRenderer<Hangin
     }
 
 	@Override
-	protected SpriteId getSignSprite(DyeColor dyeColor) {
+	protected SpriteId getSignSprite(@Nullable DyeColor dyeColor) {
 		return ModAtlases.getHangingCanvasSignMaterial(dyeColor);
 	}
 

--- a/src/main/java/vectorwing/farmersdelight/client/renderer/StandingCanvasSignRenderer.java
+++ b/src/main/java/vectorwing/farmersdelight/client/renderer/StandingCanvasSignRenderer.java
@@ -32,7 +32,7 @@ public class StandingCanvasSignRenderer extends AbstractCanvasSignRenderer<Stand
     }
 
     @Override
-    protected SpriteId getSignSprite(DyeColor color) {
+    protected SpriteId getSignSprite(@Nullable DyeColor color) {
         return ModAtlases.getCanvasSignMaterial(color);
     }
 

--- a/src/main/java/vectorwing/farmersdelight/client/renderer/state/CanvasSignRenderState.java
+++ b/src/main/java/vectorwing/farmersdelight/client/renderer/state/CanvasSignRenderState.java
@@ -2,7 +2,9 @@ package vectorwing.farmersdelight.client.renderer.state;
 
 import net.minecraft.client.renderer.blockentity.state.SignRenderState;
 import net.minecraft.world.item.DyeColor;
+import org.jspecify.annotations.Nullable;
 
 public class CanvasSignRenderState extends SignRenderState {
+    @Nullable
     public DyeColor color;
 }


### PR DESCRIPTION
Summary:
- Copy the canvas sign background dye into the render state.
- Allow both standing and hanging canvas sign renderers to select dyed sign textures, while preserving the blank canvas sign fallback.

Testing:
- sh ./gradlew build
- In-game check: colored canvas signs render with their expected colors